### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.idea.example.entities/src/org/eclipse/xtext/idea/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
+++ b/org.eclipse.xtext.idea.example.entities/src/org/eclipse/xtext/idea/example/entities/jvmmodel/EntitiesJvmModelInferrer.xtend
@@ -18,7 +18,7 @@ class EntitiesJvmModelInferrer extends AbstractModelInferrer {
 	def dispatch infer(Entity entity, extension IJvmDeclaredTypeAcceptor acceptor, boolean prelinkingPhase) {
 		accept(entity.toClass( entity.fullyQualifiedName )) [
 			documentation = entity.documentation
-			if (entity.superType != null)
+			if (entity.superType !== null)
 				superTypes += entity.superType.cloneWithProxies
 			
 			// let's add a default constructor

--- a/org.eclipse.xtext.idea.example.entities/xtend-gen/org/eclipse/xtext/idea/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
+++ b/org.eclipse.xtext.idea.example.entities/xtend-gen/org/eclipse/xtext/idea/example/entities/jvmmodel/EntitiesJvmModelInferrer.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.idea.example.entities.jvmmodel;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
@@ -44,8 +43,8 @@ public class EntitiesJvmModelInferrer extends AbstractModelInferrer {
       String _documentation = this._jvmTypesBuilder.getDocumentation(entity);
       this._jvmTypesBuilder.setDocumentation(it, _documentation);
       JvmParameterizedTypeReference _superType = entity.getSuperType();
-      boolean _notEquals = (!Objects.equal(_superType, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_superType != null);
+      if (_tripleNotEquals) {
         EList<JvmTypeReference> _superTypes = it.getSuperTypes();
         JvmParameterizedTypeReference _superType_1 = entity.getSuperType();
         JvmTypeReference _cloneWithProxies = this._jvmTypesBuilder.cloneWithProxies(_superType_1);

--- a/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/LightToolingTest.xtend
+++ b/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/LightToolingTest.xtend
@@ -84,7 +84,7 @@ class LightToolingTest extends LightCodeInsightFixtureTestCase {
 		new LightProjectDescriptor() {
 			override configureModule(Module module, ModifiableRootModel model, ContentEntry contentEntry) {
 				val languageLevelModuleExtension = model.getModuleExtension(LanguageLevelModuleExtension)
-				if (languageLevelModuleExtension != null) {
+				if (languageLevelModuleExtension !== null) {
 					languageLevelModuleExtension.languageLevel = LightToolingTest.this.languageLevel
 				}
 				addFacetToModule(module, fileType.language.ID)

--- a/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/TestDecorator.xtend
+++ b/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/TestDecorator.xtend
@@ -22,7 +22,7 @@ class TestDecoratorProcessor extends AbstractClassProcessor {
 
 	override doTransform(MutableClassDeclaration cls, extension TransformationContext context) {
 		val delegate = cls.findDeclaredField('delegate')
-		if (delegate == null) {
+		if (delegate === null) {
 			cls.addWarning("Delegate is not declared")
 			return
 		}
@@ -32,7 +32,7 @@ class TestDecoratorProcessor extends AbstractClassProcessor {
 		delegate.type.allResolvedMethods
 			.map[declaration]
 			.filter [findAnnotation(atTest) !== null && findAnnotation(atIgnore) === null]
-			.filter[cls.findDeclaredMethod(simpleName) == null]
+			.filter[cls.findDeclaredMethod(simpleName) === null]
 			.sortBy[simpleName]
 			.forEach[declaredMethod|
 				cls.addMethod(declaredMethod.simpleName) [

--- a/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/debug/AbstractDebuggerTestCase.xtend
+++ b/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/debug/AbstractDebuggerTestCase.xtend
@@ -136,7 +136,7 @@ abstract class AbstractDebuggerTestCase extends AbstractIdeaTestCase {
 		command.run
 		while (i++ < timeout / 10 &&
 			(oldSourcePosition == myDebugProcess.session.contextManager.context.sourcePosition ||
-				myDebugProcess.session.contextManager.context.sourcePosition == null)) {
+				myDebugProcess.session.contextManager.context.sourcePosition === null)) {
 			Thread.sleep(10)
 			UIUtil.dispatchAllInvocationEvents()
 		}

--- a/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.xtend
+++ b/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.xtend
@@ -40,7 +40,7 @@ class NodeModelPrinter {
 		grammarElements: «grammarElement.printGrammarElement»
 		«IF hasDirectSemanticElement»directSemanticElement: «semanticElement.class.name»«ENDIF»
 		«IF it instanceof ICompositeNode»lookAhead: «lookAhead»«ENDIF»
-		«IF !ignoreSyntaxErrors && syntaxErrorMessage != null»syntaxErrorMessage: «syntaxErrorMessage»«ENDIF»'''
+		«IF !ignoreSyntaxErrors && syntaxErrorMessage !== null»syntaxErrorMessage: «syntaxErrorMessage»«ENDIF»'''
 
 	protected dispatch def String printGrammarElement(Void grammarElement) {
 		'null'
@@ -67,11 +67,11 @@ class NodeModelPrinter {
 	'''
 
 	protected dispatch def String printGrammarElement(CrossReference crossReference) '''
-		CrossReference [«crossReference.type.classifier.name»«IF crossReference.terminal != null» | «crossReference.terminal.printGrammarElement» «ENDIF»]
+		CrossReference [«crossReference.type.classifier.name»«IF crossReference.terminal !== null» | «crossReference.terminal.printGrammarElement» «ENDIF»]
 	'''
 
 	protected dispatch def String printGrammarElement(EnumLiteralDeclaration it) '''
-		EnumLiteralDeclaration [«enumLiteral.literal»«IF literal != null» = «literal.value»«ENDIF»]
+		EnumLiteralDeclaration [«enumLiteral.literal»«IF literal !== null» = «literal.value»«ENDIF»]
 	'''
 
 }

--- a/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/LightToolingTest.java
+++ b/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/LightToolingTest.java
@@ -127,8 +127,7 @@ public class LightToolingTest extends LightCodeInsightFixtureTestCase {
       @Override
       public void configureModule(final Module module, final ModifiableRootModel model, final ContentEntry contentEntry) {
         final LanguageLevelModuleExtension languageLevelModuleExtension = model.<LanguageLevelModuleExtension>getModuleExtension(LanguageLevelModuleExtension.class);
-        boolean _notEquals = (!Objects.equal(languageLevelModuleExtension, null));
-        if (_notEquals) {
+        if ((languageLevelModuleExtension != null)) {
           LanguageLevel _languageLevel = LightToolingTest.this.getLanguageLevel();
           languageLevelModuleExtension.setLanguageLevel(_languageLevel);
         }

--- a/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/TestDecoratorProcessor.java
+++ b/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/TestDecoratorProcessor.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.tests;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtend.lib.macro.AbstractClassProcessor;
@@ -33,8 +32,7 @@ public class TestDecoratorProcessor extends AbstractClassProcessor {
   @Override
   public void doTransform(final MutableClassDeclaration cls, @Extension final TransformationContext context) {
     final MutableFieldDeclaration delegate = cls.findDeclaredField("delegate");
-    boolean _equals = Objects.equal(delegate, null);
-    if (_equals) {
+    if ((delegate == null)) {
       context.addWarning(cls, "Delegate is not declared");
       return;
     }
@@ -54,7 +52,7 @@ public class TestDecoratorProcessor extends AbstractClassProcessor {
     final Function1<MethodDeclaration, Boolean> _function_2 = (MethodDeclaration it) -> {
       String _simpleName = it.getSimpleName();
       MutableMethodDeclaration _findDeclaredMethod = cls.findDeclaredMethod(_simpleName);
-      return Boolean.valueOf(Objects.equal(_findDeclaredMethod, null));
+      return Boolean.valueOf((_findDeclaredMethod == null));
     };
     Iterable<MethodDeclaration> _filter_1 = IterableExtensions.<MethodDeclaration>filter(_filter, _function_2);
     final Function1<MethodDeclaration, String> _function_3 = (MethodDeclaration it) -> {

--- a/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/debug/AbstractDebuggerTestCase.java
+++ b/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/debug/AbstractDebuggerTestCase.java
@@ -205,7 +205,7 @@ public abstract class AbstractDebuggerTestCase extends AbstractIdeaTestCase {
       final SourcePosition oldSourcePosition = _context.getSourcePosition();
       command.run();
       while (((i++ < (AbstractDebuggerTestCase.timeout / 10)) && (Objects.equal(oldSourcePosition, this.myDebugProcess.getSession().getContextManager().getContext().getSourcePosition()) || 
-        Objects.equal(this.myDebugProcess.getSession().getContextManager().getContext().getSourcePosition(), null)))) {
+        (this.myDebugProcess.getSession().getContextManager().getContext().getSourcePosition() == null)))) {
         {
           Thread.sleep(10);
           UIUtil.dispatchAllInvocationEvents();

--- a/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.java
+++ b/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.tests.parsing;
 
-import com.google.common.base.Objects;
 import java.util.Arrays;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EEnumLiteral;
@@ -108,7 +107,7 @@ public class NodeModelPrinter {
     }
     _builder.newLineIfNotEmpty();
     {
-      if (((!this.ignoreSyntaxErrors) && (!Objects.equal(it.getSyntaxErrorMessage(), null)))) {
+      if (((!this.ignoreSyntaxErrors) && (it.getSyntaxErrorMessage() != null))) {
         _builder.append("syntaxErrorMessage: ");
         SyntaxErrorMessage _syntaxErrorMessage = it.getSyntaxErrorMessage();
         _builder.append(_syntaxErrorMessage, "");
@@ -179,8 +178,8 @@ public class NodeModelPrinter {
     _builder.append(_name, "");
     {
       AbstractElement _terminal = crossReference.getTerminal();
-      boolean _notEquals = (!Objects.equal(_terminal, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_terminal != null);
+      if (_tripleNotEquals) {
         _builder.append(" | ");
         AbstractElement _terminal_1 = crossReference.getTerminal();
         String _printGrammarElement = this.printGrammarElement(_terminal_1);
@@ -201,8 +200,8 @@ public class NodeModelPrinter {
     _builder.append(_literal, "");
     {
       Keyword _literal_1 = it.getLiteral();
-      boolean _notEquals = (!Objects.equal(_literal_1, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_literal_1 != null);
+      if (_tripleNotEquals) {
         _builder.append(" = ");
         Keyword _literal_2 = it.getLiteral();
         String _value = _literal_2.getValue();

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/BuildProgressReporter.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/BuildProgressReporter.xtend
@@ -97,7 +97,7 @@ class BuildProgressReporter implements BuildRequest.IPostValidationCallback {
 
 	protected def isUnitTestMode() {
 		val application = ApplicationManager.application
-		application == null || application.unitTestMode
+		application === null || application.unitTestMode
 	}
 
 	protected def CompilerMessage getCompilerMessage(URI validated, Issue issue) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/IdeaOutputConfigurationProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/IdeaOutputConfigurationProvider.xtend
@@ -50,7 +50,7 @@ class IdeaOutputConfigurationProvider implements IContextualOutputConfigurationP
 	
 	def Set<OutputConfiguration> getOutputConfigurations(Module module) {
 		val facet = facetProvider.getFacet(module)
-		if (facet != null) {
+		if (facet !== null) {
 			val generatorConf = facet.configuration.state
 			val defOut = new OutputConfiguration(IFileSystemAccess.DEFAULT_OUTPUT)
 			defOut.outputDirectory = generatorConf.outputDirectory.toModuleRelativePath(module)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.xtend
@@ -155,7 +155,7 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 		EditorFactory.getInstance().getEventMulticaster().addDocumentListener(new DocumentAdapter() {
 			override void documentChanged(DocumentEvent event) {
 				var file = FileDocumentManager.getInstance().getFile(event.getDocument())
-				if (file != null) {
+				if (file !== null) {
 					fileModified(file)
 				} else {
 					LOG.info("No virtual file for document. Contents was "+event.document)
@@ -358,7 +358,7 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 		alarm.cancelAllRequests
 		chunkedResourceDescriptions.removeContainer(module.name)
 		val before = moduleName2GeneratedMapping.remove(module.name)
-		if (before != null) {
+		if (before !== null) {
 			safeDeleteUris(before.allGenerated)
 		}
 		queueAllResources(module)
@@ -430,7 +430,7 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 				LOG.debug("Ignoring transitive file change "+file.path)
 			return true;
 		}
-		return file == null 
+		return file === null 
 			|| file.isDirectory 
 	}
 	
@@ -604,11 +604,11 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 	def getServiceProviderProvider(Module module) {
 		return [
 			val serviceProvider = resourceServiceProviderRegistry.getResourceServiceProvider(it)
-			if (serviceProvider != null) {
+			if (serviceProvider !== null) {
 				val facetProvider = serviceProvider.get(FacetProvider)
-				if (facetProvider != null) {
+				if (facetProvider !== null) {
 					val facet = facetProvider.getFacet(module)
-					if (facet != null) {
+					if (facet !== null) {
 						return serviceProvider
 					}
 				}
@@ -637,7 +637,7 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 				case ADDED: {
 					for (uri : event.URIs) {
 						val sourceUris = fileMappings?.getSource(uri)
-						if (sourceUris != null && !sourceUris.isEmpty) {
+						if (sourceUris !== null && !sourceUris.isEmpty) {
 							for (sourceUri : sourceUris) {
 								consistentAdd(sourceUri, changedUris, deletedUris)
 							}									
@@ -653,7 +653,7 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 				case DELETED : {
 					for (uri : event.URIs) {
 						val sourceUris = fileMappings?.getSource(uri)
-						if (sourceUris != null && !sourceUris.isEmpty) {
+						if (sourceUris !== null && !sourceUris.isEmpty) {
 							for (sourceUri : sourceUris) {
 								if (!deletedUris.contains(sourceUri)) {
 									changedUris += sourceUri
@@ -708,11 +708,11 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 	}
 	
 	protected def Module findModule(VirtualFile file, ProjectFileIndex fileIndex) {
-		if (file == null) {
+		if (file === null) {
 			return null
 		}
 		val module = fileIndex.getModuleForFile(file, true)
-		if (module != null)
+		if (module !== null)
 			return module
 		return file.parent.findModule(fileIndex)
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/DerivedMemberAwarePsiModelAssociations.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/DerivedMemberAwarePsiModelAssociations.xtend
@@ -23,11 +23,11 @@ class DerivedMemberAwarePsiModelAssociations extends PsiModelAssociations {
 	extension IJvmModelAssociations jvmModelAssociations
 
 	override getPsiElement(EObject object) {
-		if (object == null)
+		if (object === null)
 			return null	
 		
 		val psiElement = super.getPsiElement(convertToSource(object))
-		if (psiElement == null)
+		if (psiElement === null)
 			// TODO: a hack just to be symmetric with Eclipse in the case if a primary source element is not set
 			object.eContainer.psiElement
 		else

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/PsiBasedTypeFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/PsiBasedTypeFactory.xtend
@@ -108,7 +108,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 			ApplicationManager.application.<JvmDeclaredType>runReadAction[
 				val buffer = new StringBuilder(100)
 				val packageName = psiClass.packageName
-				if (packageName != null) {
+				if (packageName !== null) {
 					buffer.append(packageName).append('.')
 				}
 				val type = psiClass.createType(buffer)
@@ -162,7 +162,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 		val modifierList = psiModifierListOwner.modifierList
 		for (annotation : modifierList.annotations) {
 			val annotationReference = annotation.createAnnotationReference
-			if (annotationReference != null) {
+			if (annotationReference !== null) {
 				annotations.addUnique(annotationReference)
 			}
 		}
@@ -228,7 +228,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 			default:
 				createJvmField => [
 					val value = field.constantValue
-					if (value != null) {
+					if (value !== null) {
 						constant = true
 						constantValue = value
 					} else {
@@ -334,7 +334,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 	protected def setDefaultValue(JvmOperation operation, PsiMethod method) {
 		if (method instanceof PsiAnnotationMethod) {
 			val defaultValue = method.defaultValue.computeAnnotationValue(method.project)
-			if (defaultValue != null) {
+			if (defaultValue !== null) {
 				val annotationValue = defaultValue.createAnnotationValue(method)
 				operation.defaultValue = annotationValue
 				annotationValue.operation = operation
@@ -396,7 +396,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 				values.addUnique((value as PsiType).createTypeReference)
 			JvmAnnotationAnnotationValue: {
 				val annotationReference = (value as PsiAnnotation).createAnnotationReference
-				if (annotationReference != null) {
+				if (annotationReference !== null) {
 					values.addUnique(annotationReference)
 				}
 			}
@@ -695,7 +695,7 @@ class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements ITypeFa
 	}
 
 	protected def isInnerTypeReference(PsiClass psiClass) {
-		psiClass.containingClass != null && !psiClass.hasModifierProperty(PsiModifier.STATIC)
+		psiClass.containingClass !== null && !psiClass.hasModifierProperty(PsiModifier.STATIC)
 	}
 
 	protected def dispatch JvmTypeReference createTypeArgument(PsiType type) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/StubJvmTypeProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/StubJvmTypeProvider.xtend
@@ -65,11 +65,11 @@ class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
 
 	override findTypeByName(String name, boolean binaryNestedTypeDelimiter) {
 		var result = doFindTypeByName(name, false)
-		if (result != null || isBinaryNestedTypeDelimiter(name, binaryNestedTypeDelimiter)) {
+		if (result !== null || isBinaryNestedTypeDelimiter(name, binaryNestedTypeDelimiter)) {
 			return result
 		}
 		val nameVariants = new ClassNameVariants(name)
-		while (result == null && nameVariants.hasNext) {
+		while (result === null && nameVariants.hasNext) {
 			val nextVariant = nameVariants.next
 			result = doFindTypeByName(nextVariant, true)
 		}
@@ -115,11 +115,11 @@ class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
 		ProgressIndicatorProvider.checkCanceled
 		try {
 			val existing = resourceSet.getResource(resourceURI, false)
-			if (existing != null) {
+			if (existing !== null) {
 				return existing.findType(fragment, traverseNestedTypes)
 			}
 			val mirror = createMirror(resourceURI)
-			if (mirror == null) {
+			if (mirror === null) {
 				return null
 			}
 			val resource = doCreateResource(resourceURI)
@@ -135,7 +135,7 @@ class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
 	protected def findType(Resource resource, String fragment, boolean traverseNestedTypes) {
 		ApplicationManager.application.<JvmType>runReadAction[
 			val result = resource.getEObject(fragment) as JvmType
-			if (result != null || !traverseNestedTypes) {
+			if (result !== null || !traverseNestedTypes) {
 				return result
 			}
 			val rootType = resource.contents.head
@@ -153,7 +153,7 @@ class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
 		ApplicationManager.application.<IClassMirror>runReadAction[
 			try {
 				val psiClass = JavaPsiFacade.getInstance(module.project).findClass(name, searchScope)
-				if (psiClass == null || psiClass.containingClass != null) {
+				if (psiClass === null || psiClass.containingClass !== null) {
 					return null
 				}
 				new PsiClassMirror(psiClass, psiClassFactory)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/StubURIHelper.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/common/types/StubURIHelper.xtend
@@ -119,7 +119,7 @@ class StubURIHelper implements URIHelperConstants {
 			return builder.appendTypeParameterResourceURI(psiClass)
 		}
 		val containingClass = psiClass.containingClass
-		if (containingClass != null) {
+		if (containingClass !== null) {
 			builder.appendClassResourceURI(containingClass)
 		} else {
 			builder.append(OBJECTS).append(psiClass.qualifiedName)
@@ -156,7 +156,7 @@ class StubURIHelper implements URIHelperConstants {
 			return builder.appendTypeParameterFragment(psiClass);	
 		}
 		val containingClass = psiClass.containingClass
-		if (containingClass == null) {
+		if (containingClass === null) {
 			return builder.append(psiClass.qualifiedName)
 		} else {
 			return builder.appendClassFragment(containingClass).append('$').append(psiClass.name)
@@ -197,7 +197,7 @@ class StubURIHelper implements URIHelperConstants {
 				val resolved = type.resolve
 				switch resolved {
 					PsiTypeParameter: builder.append(resolved.name)
-					case resolved != null: builder.appendTypeName(resolved)
+					case resolved !== null: builder.appendTypeName(resolved)
 					default: builder.append(PsiNameHelper.getQualifiedClassName(type.canonicalText, false))
 				}
 			}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.xtend
@@ -134,7 +134,7 @@ abstract class AbstractCompletionContributor extends CompletionContributor {
 			
 		val tokenSet = (parameters.editor as EditorEx).getTokenSet(parameters.offset)
 		val providers = myContributors.get(parameters.getCompletionType()).get(tokenSet)
-		if (providers == null)
+		if (providers === null)
 			return;
 			
 		val calledProviders = newHashSet
@@ -155,7 +155,7 @@ abstract class AbstractCompletionContributor extends CompletionContributor {
 			
 		val tokenSet = (parameters.editor as EditorEx).getTokenSet(parameters.offset)
 		val element2provider = myFollowElementBasedContributors.get(parameters.getCompletionType()).get(tokenSet)
-		if (element2provider == null)
+		if (element2provider === null)
 			return;
 		
 		val followElements = computeFollowElements(parameters)
@@ -206,7 +206,7 @@ abstract class AbstractCompletionContributor extends CompletionContributor {
 			return;
 
 		val delegate = parserBasedDelegate
-		if (delegate == null)
+		if (delegate === null)
 			return;
 		val contexts = delegate.create(parameters.text, parameters.selection, parameters.offset, parameters.resource)
 		contexts.forEach[c|c.firstSetGrammarElements.forEach[e|createProposal(e, c, parameters, result)]]
@@ -217,7 +217,7 @@ abstract class AbstractCompletionContributor extends CompletionContributor {
 	}
 
 	protected def getParserBasedDelegate() {
-		if (delegates == null)
+		if (delegates === null)
 			return null
 		delegates.get => [it.pool = pool]
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/DebugProcessExtensions.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/DebugProcessExtensions.xtend
@@ -48,7 +48,7 @@ class DebugProcessExtensions {
 		val uri = javaSource.file.virtualFile.getURI
 		val lastSegmentOfTrace = traceFileNameProvider.getTraceFromJava(uri.lastSegment)
 		val virtualFile = uri.trimSegments(1).appendSegment(lastSegmentOfTrace).virtualFile
-		if (virtualFile == null || !virtualFile.exists) {
+		if (virtualFile === null || !virtualFile.exists) {
 			return null
 		}
 		val trace = traceRegionSerializer.readTraceRegionFrom(virtualFile.inputStream)
@@ -68,7 +68,7 @@ class DebugProcessExtensions {
 		for (uri : generated.filter[fileExtension=='java']) {
 			val lastSegmentOfTrace = traceFileNameProvider.getTraceFromJava(uri.lastSegment)
 			val virtualFile = uri.trimSegments(1).appendSegment(lastSegmentOfTrace).virtualFile
-			if (virtualFile != null && virtualFile.exists) {
+			if (virtualFile !== null && virtualFile.exists) {
 				val trace = traceRegionSerializer.readTraceRegionFrom(virtualFile.inputStream)
 				result.put(uri,trace)
 			}
@@ -82,7 +82,7 @@ class DebugProcessExtensions {
 		
 	def URI findOriginalDeclaration(DebugProcess process, Location location) {
 		val psiFile = process.getPsiFile(location)
-		if (psiFile == null)
+		if (psiFile === null)
 			return null
 		else 
 			return process.project.getComponent(XtextAutoBuilderComponent).getSource4GeneratedSource(psiFile.virtualFile.getURI).head

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/SkippingUnwantedSteppingFilter.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/SkippingUnwantedSteppingFilter.xtend
@@ -33,7 +33,7 @@ class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
 	}
 	
 	override isApplicable(SuspendContext context) {
-		if (context == null || !isXtextSourced(context)) {
+		if (context === null || !isXtextSourced(context)) {
             return false;
         }
         val debugProcess = context.getDebugProcess()
@@ -41,7 +41,7 @@ class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
         val location = context.getFrameProxy().location()
         if (isEmptyAnonymousClassConstructor(context))
         	return true;
-        val result = positionManager.getSourcePosition(location) == null
+        val result = positionManager.getSourcePosition(location) === null
         if (result) {
         	return true
         }
@@ -50,14 +50,14 @@ class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
 	
 	protected def boolean isXtextSourced(SuspendContext context) {
 		val location = context.frameProxy.location
-		return context.debugProcess.findOriginalDeclaration(location) != null
+		return context.debugProcess.findOriginalDeclaration(location) !== null
 	}
 		
 	def isEmptyAnonymousClassConstructor(SuspendContext context) {
 		val Location location = context.frameProxy.location
-        if (location != null) {
+        if (location !== null) {
           val Method method = location.method();
-          if (method != null && method.isConstructor() && method.argumentTypes.isEmpty && method.declaringType.name.indexOf('$') > 0) {
+          if (method !== null && method.isConstructor() && method.argumentTypes.isEmpty && method.declaringType.name.indexOf('$') > 0) {
             return true
           }
         }

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.xtend
@@ -93,7 +93,7 @@ class TraceBasedPositionManagerFactory extends PositionManagerFactory {
 			val line = source.line
 			for (uri2trace : traces.entrySet) {
 				val region = uri2trace.value.treeIterator.findFirst[associatedLocations.head?.lineNumber == line]
-				if (region != null) {
+				if (region !== null) {
 					val psiFile = process.getPsiFile(uri2trace.key)
 					val classes = process.javaPositionManger.getAllClasses(SourcePosition.createFromLine(psiFile, region.myLineNumber+1))
 					allClasses.addAll(classes)
@@ -105,11 +105,11 @@ class TraceBasedPositionManagerFactory extends PositionManagerFactory {
 		override getSourcePosition(Location location) throws NoDataException {
 			val line = location.lineNumber -1
 			val psiFile = process.getPsiFile(location)
-			if (psiFile == null) {
+			if (psiFile === null) {
 				throw NoDataException.INSTANCE
 			}
 			val trace = SourcePosition.createFromLine(psiFile, line).traceForJava
-			if (trace == null) {
+			if (trace === null) {
 				throw NoDataException.INSTANCE
 			}
 			val sourceURI = process.findOriginalDeclaration(location)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/documentation/IdeaDocumentationProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/documentation/IdeaDocumentationProvider.xtend
@@ -30,15 +30,15 @@ class IdeaDocumentationProvider extends AbstractDocumentationProvider {
 
 	override getQuickNavigateInfo(PsiElement element, PsiElement originalElement) {
 		val gen = findDocumentationInGeneratedCode(element, originalElement)
-		if (gen != null) {
+		if (gen !== null) {
 			val result = gen.delegate.getQuickNavigateInfo(gen.generatedElement, gen.generatedOriginalElement)
-			if (result != null)
+			if (result !== null)
 				return result
 		}
 		if (element instanceof PsiEObject) {
 			val eobj = element.EObject
 			val result = eobj.calleeDocumentationProvider?.getQuickNavigateInfo(element)
-			if (result != null)
+			if (result !== null)
 				return result
 			return EcoreUtil.getURI(eobj).toString
 		}
@@ -47,15 +47,15 @@ class IdeaDocumentationProvider extends AbstractDocumentationProvider {
 
 	override generateDoc(PsiElement element, PsiElement originalElement) {
 		val gen = findDocumentationInGeneratedCode(element, originalElement)
-		if (gen != null) {
+		if (gen !== null) {
 			val result = gen.delegate.generateDoc(gen.generatedElement, gen.generatedOriginalElement)
-			if (result != null)
+			if (result !== null)
 				return result
 		}
 		if (element instanceof PsiEObject) {
 			val eobj = element.EObject
 			val result = eobj.calleeDocumentationProvider?.generateDoc(element)
-			if (result != null)
+			if (result !== null)
 				return result
 			return EcoreUtil.getURI(eobj).toString
 		}
@@ -63,11 +63,11 @@ class IdeaDocumentationProvider extends AbstractDocumentationProvider {
 	}
 
 	def protected IdeaDeclarationDocumentationProvider getCalleeDocumentationProvider(EObject object) {
-		if (object == null || object.eIsProxy)
+		if (object === null || object.eIsProxy)
 			return null
 		val uri = object.eResource.URI
 		val resourceServiceProvider = resourceServiceProviderRegistry.getResourceServiceProvider(uri)
-		if (resourceServiceProvider == null)
+		if (resourceServiceProvider === null)
 			return null
 		return resourceServiceProvider?.get(IdeaDeclarationDocumentationProvider)
 	}
@@ -75,11 +75,11 @@ class IdeaDocumentationProvider extends AbstractDocumentationProvider {
 	def protected GeneratedCodeDelegate findDocumentationInGeneratedCode(PsiElement element,
 		PsiElement originalElement) {
 		val generatedElement = element.generatedElement
-		if (generatedElement == null)
+		if (generatedElement === null)
 			return null
 		val generatedOriginalElement = originalElement.generatedElement ?: originalElement
 		val delegate = DocumentationManager.getProviderFromElement(generatedElement, generatedOriginalElement)
-		if (delegate == null)
+		if (delegate === null)
 			return null
 		return new GeneratedCodeDelegate(generatedElement, generatedOriginalElement, delegate)
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AbstractIndentableAutoEditBlock.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AbstractIndentableAutoEditBlock.xtend
@@ -44,7 +44,7 @@ abstract class AbstractIndentableAutoEditBlock extends AbstractAutoEditBlock {
 	IIndentationInformation indentationInformation
 
 	protected def getIndentationTerminal() {
-		if (indentationTerminal == null)
+		if (indentationTerminal === null)
 			return indentationInformation.indentString
 		return indentationTerminal
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AutoEditMultiLineBlock.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AutoEditMultiLineBlock.xtend
@@ -43,18 +43,18 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 
 	protected def findRegion(int offset, extension AutoEditContext context) {
 		val openingTerminal = findOpeningTerminal(offset, context)
-		if (openingTerminal == null)
+		if (openingTerminal === null)
 			return null
 
 		var closingTerminal = findClosingTerminal(offset, context)
 		if (closingTerminal != -1 && nested) {
 			var previousOpeningTerminal = openingTerminal
 			var previousClosingTerminal = closingTerminal
-			while (closingTerminal != null && previousOpeningTerminal != null && previousClosingTerminal != null) {
+			while (closingTerminal !== null && previousOpeningTerminal !== null && previousClosingTerminal !== null) {
 				previousOpeningTerminal = findOpeningTerminal(previousOpeningTerminal.offset, context)
-				if (previousOpeningTerminal != null) {
+				if (previousOpeningTerminal !== null) {
 					previousClosingTerminal = findClosingTerminal(previousClosingTerminal.offset + 1, context)
-					if (previousClosingTerminal == null)
+					if (previousClosingTerminal === null)
 						closingTerminal = null
 				}
 			}
@@ -69,10 +69,10 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 		var rightOffset = offset
 		while (true) {
 			val openingTerminal = text.searchBackward(this.openingTerminal, leftOffset, context)
-			if (openingTerminal == null)
+			if (openingTerminal === null)
 				return null
 			val closingTerminal = text.searchBackward(this.closingTerminal, rightOffset, context)
-			if (closingTerminal == null || closingTerminal.offset < openingTerminal.offset)
+			if (closingTerminal === null || closingTerminal.offset < openingTerminal.offset)
 				return openingTerminal
 
 			leftOffset = openingTerminal.offset
@@ -87,10 +87,10 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 		var rightOffset = offset
 		while (true) {
 			val closingTerminal = text.searchForward(this.closingTerminal, rightOffset, context)
-			if (closingTerminal == null)
+			if (closingTerminal === null)
 				return null
 			val openingTerminal = text.searchForward(this.openingTerminal, leftOffset, context)
-			if (openingTerminal == null || openingTerminal.offset > closingTerminal.offset)
+			if (openingTerminal === null || openingTerminal.offset > closingTerminal.offset)
 				return closingTerminal
 
 			rightOffset = findNextOffset(rightOffset, closingTerminal.offset + closingTerminal.length, context)
@@ -160,7 +160,7 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 		val caretOffset = caretOffset
 		if (region.openingTerminal.offset.isSameLine(caretOffset)) {
 			val closingTerminal = region.getClosingTerminal(context)
-			if (closingTerminal == null) {
+			if (closingTerminal === null) {
 				close(previousLineIndentation, context)
 			} else if (closingTerminal.offset.isSameLine(caretOffset) && closingTerminal.offset >= caretOffset) {
 				val text = getText(caretOffset, closingTerminal.offset).trim
@@ -169,7 +169,7 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 			return indentationTerminal
 		}
 
-		if (region.closingTerminal == null) {
+		if (region.closingTerminal === null) {
 			close(previousLineIndentation, context)
 			return ''
 		}
@@ -179,7 +179,7 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 
 	protected def getClosingTerminal(AutoEditBlockRegion region, extension AutoEditContext context) {
 		val closingTerminal = region.closingTerminal
-		if (closingTerminal == null)
+		if (closingTerminal === null)
 			return null
 
 		if (closingTerminal.length < this.closingTerminal.length && closingTerminal.offset.isSameLine(caretOffset))
@@ -204,13 +204,13 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 
 	override close(char c, extension AutoEditContext context) {
 		val region = caretOffset.findRegion(context)
-		if (region == null)
+		if (region === null)
 			return false
 
 		val openedRegion = region.findOpenedRegion(context)
-		if (openedRegion != null)
+		if (openedRegion !== null)
 			type(c)
-		else if (region.closingTerminal != null && region.closingTerminal.contains(caretOffset))
+		else if (region.closingTerminal !== null && region.closingTerminal.contains(caretOffset))
 			editor.moveCaretRelatively(1)
 		else
 			type(c)
@@ -219,9 +219,9 @@ class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
 	}
 
 	protected def AutoEditBlockRegion findOpenedRegion(AutoEditBlockRegion region, extension AutoEditContext context) {
-		if (region == null)
+		if (region === null)
 			return null
-		if (region.closingTerminal == null)
+		if (region.closingTerminal === null)
 			return region
 		val nextRegion = region.openingTerminal.offset.findRegion(context)
 		return nextRegion.findOpenedRegion(context)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AutoEditString.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/AutoEditString.xtend
@@ -40,10 +40,10 @@ class AutoEditString extends AbstractAutoEditBlock {
 
 	override close(char c, extension AutoEditContext context) {
 		val stringRegion = caretOffset.findRegion(context)
-		if (stringRegion == null)
+		if (stringRegion === null)
 			return false
 
-		if (stringRegion.closingTerminal == null)
+		if (stringRegion.closingTerminal === null)
 			type(c)
 		else if (stringRegion.closingTerminal.contains(caretOffset))
 			editor.moveCaretRelatively(1)
@@ -55,11 +55,11 @@ class AutoEditString extends AbstractAutoEditBlock {
 
 	protected def AutoEditStringRegion findRegion(int offset, extension AutoEditContext context) {
 		val openingTerminal = offset.findOpeningTerminal(context)
-		if (openingTerminal == null)
+		if (openingTerminal === null)
 			return null
 
 		val closingTerminal = offset.findClosingTerminal(openingTerminal.offset, context)
-		if (closingTerminal != null) {
+		if (closingTerminal !== null) {
 			if (openingTerminal.offset >= offset)
 				return null
 			if (closingTerminal.offset + closingTerminal.length <= offset)
@@ -79,7 +79,7 @@ class AutoEditString extends AbstractAutoEditBlock {
 
 		while (!iterator.atEnd) {
 			val openingTerminal = iterator.getOpeningTerminal(context)
-			if (openingTerminal != null)
+			if (openingTerminal !== null)
 				return openingTerminal
 
 			iterator.retreat
@@ -98,7 +98,7 @@ class AutoEditString extends AbstractAutoEditBlock {
 
 		while (!iterator.atEnd) {
 			val closingTerminal = iterator.getClosingTerminal(openingTokenOffset, context)
-			if (closingTerminal != null)
+			if (closingTerminal !== null)
 				return closingTerminal
 
 			iterator.advance
@@ -110,7 +110,7 @@ class AutoEditString extends AbstractAutoEditBlock {
 		HighlighterIterator iterator,
 		extension AutoEditContext context
 	) {
-		if (iterator == null)
+		if (iterator === null)
 			return null
 
 		if (iterator.end - iterator.start < openingTerminal.length)
@@ -127,7 +127,7 @@ class AutoEditString extends AbstractAutoEditBlock {
 		int openingTokenOffset,
 		extension AutoEditContext context
 	) {
-		if (iterator == null)
+		if (iterator === null)
 			return null
 
 		if (iterator.end - openingTokenOffset < openingTerminal.length + closingTerminal.length)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/DefaultAutoEditHandler.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/DefaultAutoEditHandler.xtend
@@ -47,7 +47,7 @@ class DefaultAutoEditHandler extends IdeaAutoEditHandler {
 	) {
 		val context = new AutoEditContext(editor, tokenSetProvider)
 		val region = findBlockRegion(context)
-		if (region == null)
+		if (region === null)
 			return Result.CONTINUE
 
 		return handleIndentation(region, context)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditBackspaceHandler.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditBackspaceHandler.xtend
@@ -19,13 +19,13 @@ class XtextAutoEditBackspaceHandler extends BackspaceHandlerDelegate {
 
 	override beforeCharDeleted(char c, PsiFile file, Editor editor) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler != null)
+		if (autoEditHandler !== null)
 			autoEditHandler.beforeCharDeleted(c, file, editor as EditorEx)
 	}
 
 	override charDeleted(char c, PsiFile file, Editor editor) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler != null)
+		if (autoEditHandler !== null)
 			autoEditHandler.charDeleted(c, file, editor as EditorEx)
 		else
 			false

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditEnterHandler.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditEnterHandler.xtend
@@ -29,7 +29,7 @@ class XtextAutoEditEnterHandler extends EnterHandlerDelegateAdapter {
 		EditorActionHandler originalHandler
 	) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler == null)
+		if (autoEditHandler === null)
 			return super.preprocessEnter(
 				file,
 				editor,
@@ -50,7 +50,7 @@ class XtextAutoEditEnterHandler extends EnterHandlerDelegateAdapter {
 
 	override postProcessEnter(PsiFile file, Editor editor, DataContext dataContext) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler == null)
+		if (autoEditHandler === null)
 			return super.postProcessEnter(file, editor, dataContext)
 		return autoEditHandler.enterTyped(file, editor as EditorEx, dataContext).translateResult
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditTypedHandler.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/editorActions/XtextAutoEditTypedHandler.xtend
@@ -21,14 +21,14 @@ class XtextAutoEditTypedHandler extends TypedHandlerDelegate {
 
 	override beforeCharTyped(char c, Project project, Editor editor, PsiFile file, FileType fileType) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler == null)
+		if (autoEditHandler === null)
 			return super.beforeCharTyped(c, project, editor, file, fileType)
 		return autoEditHandler.beforeCharTyped(c, project, editor as EditorEx, file, fileType).translateResult
 	}
 
 	override charTyped(char c, Project project, Editor editor, PsiFile file) {
 		val autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(file.language)
-		if (autoEditHandler == null)
+		if (autoEditHandler === null)
 			return super.charTyped(c, project, editor, file)
 		return autoEditHandler.charTyped(c, project, editor as EditorEx, file).translateResult
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.xtend
@@ -67,7 +67,7 @@ class ConfigurationProducerExtensions {
 			return emptySet
 		}
 		val fileInProject = VirtualFileInProject.forPsiElement(xtextFile)
-		if (fileInProject == null) {
+		if (fileInProject === null) {
 			return emptySet
 		}
 		val IIdeaTrace trace = traceProvider.getTraceToTarget(fileInProject)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/TraceBasedExceptionFilterFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/TraceBasedExceptionFilterFactory.xtend
@@ -45,26 +45,26 @@ class TraceBasedExceptionFilter extends ExceptionFilter {
 
 	override applyFilter(String line, int textEndOffset) {
 		val result = super.applyFilter(line, textEndOffset)
-		if (result == null)
+		if (result === null)
 			return null
 
-		val resultItem = result.resultItems.findFirst[getHyperlinkInfo != null]
+		val resultItem = result.resultItems.findFirst[getHyperlinkInfo !== null]
 		val hyperlinkInfo = resultItem.getHyperlinkInfo
 		if (hyperlinkInfo instanceof FileHyperlinkInfo) {
 			val descriptor = hyperlinkInfo.descriptor
-			if (descriptor != null) {
+			if (descriptor !== null) {
 				val fileInProject = new VirtualFileInProject(descriptor.file, descriptor.project)
 				if (traceProvider.isGenerated(fileInProject)) {
 					val trace = traceProvider.getTraceToSource(fileInProject)
 					val rangeMarker = descriptor.rangeMarker
-					if (trace != null && rangeMarker != null) {
+					if (trace !== null && rangeMarker !== null) {
 						val nonSpaceCharOffset = ApplicationManager.application.<Integer>runReadAction[
 							val document = FileDocumentManager.instance.getDocument(descriptor.file)
 							val lineNumber = document.getLineNumber(rangeMarker.startOffset)
 							DocumentUtil.getFirstNonSpaceCharOffset(document, lineNumber)
 						]
 						val location = trace.getBestAssociatedLocation(new TextRegion(nonSpaceCharOffset, 0))
-						if (location != null) {
+						if (location !== null) {
 							val sourceFileDescriptor = new OpenFileDescriptor(
 								location.platformResource.project,
 								location.platformResource.file,

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/AbstractExecutableExtensionPoint.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/AbstractExecutableExtensionPoint.xtend
@@ -27,9 +27,9 @@ abstract class AbstractExecutableExtensionPoint extends AbstractExtensionPointBe
 	}
 
 	def createInstance() {
-		if (implementationClass == null)
+		if (implementationClass === null)
 			throw 'Class is not specified'.asRuntimeException
-		if (factoryClass == null)
+		if (factoryClass === null)
 			implementationClass.findClass.newInstance
 		else
 			factoryClass.<ExtensionFactory>findClass.newInstance.createInstance(null, implementationClass)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.xtend
@@ -31,11 +31,11 @@ class EcoreGlobalRegistries {
 
 		val registry = IResourceServiceProvider.Registry.INSTANCE
 		Extensions.getExtensions(ResourceServiceProviderEP.EP_NAME).forEach [
-			if (uriExtension != null)
+			if (uriExtension !== null)
 				registry.extensionToFactoryMap.put(uriExtension, createDescriptor)
-			if (protocolName != null)
+			if (protocolName !== null)
 				registry.protocolToFactoryMap.put(protocolName, createDescriptor)
-			if (contentTypeIdentifier != null)
+			if (contentTypeIdentifier !== null)
 				registry.contentTypeToFactoryMap.put(contentTypeIdentifier, createDescriptor)
 		]
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/ResourceFactoryEP.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/ResourceFactoryEP.xtend
@@ -40,7 +40,7 @@ class ResourceFactoryDescriptor implements Resource.Factory.Descriptor {
 	Resource.Factory factory
 
 	override createFactory() {
-		if (factory == null)
+		if (factory === null)
 			factory = extensionPoint.createInstance as Resource.Factory
 		return factory
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/ResourceServiceProviderEP.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/ResourceServiceProviderEP.xtend
@@ -52,7 +52,7 @@ class ResourceServiceProviderDescriptor extends AbstractResourceServiceProviderD
 	}
 
 	override protected getExtension() {
-		if (myExtension == null)
+		if (myExtension === null)
 			myExtension = extensionPoint.createInstance
 		return myExtension
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/RootModelExtensions.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/RootModelExtensions.xtend
@@ -19,7 +19,7 @@ class RootModelExtensions {
 	}
 	
 	static def getExistingSourceFolders(Module module) {
-		module.sourceFolders.filter[file != null]
+		module.sourceFolders.filter[file !== null]
 	}
 
 	static def getRelativePath(SourceFolder sourceFolder) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/facet/GeneratorConfigurationState.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/facet/GeneratorConfigurationState.xtend
@@ -10,7 +10,7 @@ class GeneratorConfigurationState {
 
 	new(OutputConfiguration defOutput) {
 		activated = true
-		if (defOutput != null) {
+		if (defOutput !== null) {
 			var outputDir = defOutput.outputDirectory
 			if ("./src-gen" == outputDir) {
 				outputDir = "src-gen"

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/filesystem/IdeaProjectConfigProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/filesystem/IdeaProjectConfigProvider.xtend
@@ -62,14 +62,14 @@ class IdeaProjectConfigProvider implements IProjectConfigProvider {
 
 	override IdeaSourceFolder findSourceFolderContaining(URI member) {
 		val file = VirtualFileManager.instance.findFileByUrl(member.toString)
-		if (file == null)
+		if (file === null)
 			return null
 
 		val sourceRoot = ProjectRootManager.getInstance(module.project).fileIndex.getSourceRootForFile(file)
-		if (sourceRoot == null) return null
+		if (sourceRoot === null) return null
 		
 		val sourceFolder = module.findSourceFolder(sourceRoot)
-		if (sourceFolder == null || sourceFolder.contentEntry.file != contentRoot) return null
+		if (sourceFolder === null || sourceFolder.contentEntry.file != contentRoot) return null
 
 		return new IdeaSourceFolder(sourceFolder)
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/findusages/GeneratedSourceAwareUsagesHandlerFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/findusages/GeneratedSourceAwareUsagesHandlerFactory.xtend
@@ -103,7 +103,7 @@ class GeneratedSourceAwareUsagesHandlerFactory extends FindUsagesHandlerFactory 
 		val result = newArrayList
 		for (generatedElement : traceProvider.getGeneratedElements(element)) {
 			val parent = PsiTreeUtil.getParentOfType(generatedElement, PsiNamedElement, false)
-			if (parent != null && !result.contains(parent)) {
+			if (parent !== null && !result.contains(parent)) {
 				result.add(parent)
 			}	
 		}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/BlockExtension.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/BlockExtension.xtend
@@ -53,7 +53,7 @@ class BlockExtension {
 	}
 
 	def isOpening(ASTNode node) {
-		if (node == null)
+		if (node === null)
 			return false
 
 		val text = node.text
@@ -61,7 +61,7 @@ class BlockExtension {
 	}
 
 	def isClosing(ASTNode node) {
-		if (node == null)
+		if (node === null)
 			return false
 
 		val text = node.text
@@ -73,7 +73,7 @@ class BlockExtension {
 	}
 
 	def getBracePairForOpeningNode(ASTNode node) {
-		if (node == null)
+		if (node === null)
 			return null
 
 		val openingBrace = node.text
@@ -85,7 +85,7 @@ class BlockExtension {
 	}
 
 	def getBracePairForClosingNode(ASTNode node) {
-		if (node == null)
+		if (node === null)
 			return null
 
 		val openingBrace = node.text
@@ -97,7 +97,7 @@ class BlockExtension {
 		val offset = block.textRange.startOffset - node.startOffset
 		val leafElement = node.findLeafElementAt(offset)
 		val bracePair = leafElement.bracePairForOpeningNode
-		bracePair != null && bracePair.structural
+		bracePair !== null && bracePair.structural
 	}
 
 	def getBracePairs() {
@@ -107,7 +107,7 @@ class BlockExtension {
 	public static val STRUCTURAL_INDENT = Indent.getIndent(Indent.Type.NORMAL, false, true)
 
 	def getIndent(BracePair bracePair, boolean enforceIndentToChildren) {
-		if (bracePair == null)
+		if (bracePair === null)
 			return Indent.noneIndent
 
 		if (bracePair.structural)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultBlockFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultBlockFactory.xtend
@@ -54,7 +54,7 @@ class DefaultBlockFactory implements BlockFactory {
 			return null
 
 		val blockTextRange = node.createTextRange
-		if (blockTextRange == null || blockTextRange.empty || !parentBlock.textRange.contains(blockTextRange))
+		if (blockTextRange === null || blockTextRange.empty || !parentBlock.textRange.contains(blockTextRange))
 			return null
 
 		val spacingBuilder = if(parentBlock instanceof ModifiableBlock) parentBlock.spacingBuilder
@@ -103,13 +103,13 @@ class DefaultBlockFactory implements BlockFactory {
 			}
 			return textRange
 		}
-		if (node.firstChildNode == null)
+		if (node.firstChildNode === null)
 			return textRange
 
 		val firstNonHiddenLeafNode = node.findFirstLeaf.findNode([nextLeaf], [
 			!whitespaceOrEmpty || !textRange.contains(it.textRange)
 		])
-		if (firstNonHiddenLeafNode == null || !textRange.contains(firstNonHiddenLeafNode.textRange))
+		if (firstNonHiddenLeafNode === null || !textRange.contains(firstNonHiddenLeafNode.textRange))
 			return null
 
 		val startOffset = firstNonHiddenLeafNode.startOffset
@@ -118,7 +118,7 @@ class DefaultBlockFactory implements BlockFactory {
 	}
 
 	protected def ASTNode findNode(ASTNode node, (ASTNode)=>ASTNode provider, (ASTNode)=>boolean condition) {
-		if (node == null)
+		if (node === null)
 			return null
 
 		if (condition.apply(node))

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultChildAttributesProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultChildAttributesProvider.xtend
@@ -37,7 +37,7 @@ class DefaultChildAttributesProvider implements ChildAttributesProvider {
 			return block.getAfterChildIndent(children.size)
 
 		val indent = block.getBeforeChildIndent(newChildIndex)
-		if (indent == null)
+		if (indent === null)
 			return block.getAfterChildIndent(newChildIndex)
 
 		return indent
@@ -76,11 +76,11 @@ class DefaultChildAttributesProvider implements ChildAttributesProvider {
 	}
 
 	protected def Indent getAfterChildIndent(Block block) {
-		if (block == null)
+		if (block === null)
 			return null
 		
 		val grammarElementIndent = block.grammarElement.indentAfter
-		if (grammarElementIndent != null)
+		if (grammarElementIndent !== null)
 			return grammarElementIndent
 
 		if (block instanceof SyntheticXtextBlock)
@@ -97,11 +97,11 @@ class DefaultChildAttributesProvider implements ChildAttributesProvider {
 	}
 
 	protected def Indent getBeforeChildIndent(Block block) {
-		if (block == null)
+		if (block === null)
 			return null
 
 		val grammarElementIndent = block.grammarElement.indentBefore
-		if (grammarElementIndent != null)
+		if (grammarElementIndent !== null)
 			return grammarElementIndent
 
 		if (block instanceof SyntheticXtextBlock)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultCommenter.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultCommenter.xtend
@@ -57,22 +57,22 @@ class DefaultCommenter implements CodeDocumentationAwareCommenter {
 		extension ITokenDefProvider tokenDefProvider
 	) {
 		val mlCommentEntry = tokenDefMap.entrySet.findFirst[value == tokenName]
-		if (mlCommentEntry != null)
+		if (mlCommentEntry !== null)
 			mlCommentEntry.key.getIElementType
 	}
 
 	override getLineCommentPrefix() {
-		if (slCommentTokenType != null)
+		if (slCommentTokenType !== null)
 			return lineCommentPrefix
 	}
 
 	override getBlockCommentPrefix() {
-		if (mlCommentTokenType != null)
+		if (mlCommentTokenType !== null)
 			return blockCommentPrefix
 	}
 
 	override getBlockCommentSuffix() {
-		if (mlCommentTokenType != null)
+		if (mlCommentTokenType !== null)
 			return blockCommentSuffix
 	}
 
@@ -89,7 +89,7 @@ class DefaultCommenter implements CodeDocumentationAwareCommenter {
 	}
 
 	override getDocumentationCommentLinePrefix() {
-		if (mlCommentTokenType != null)
+		if (mlCommentTokenType !== null)
 			return documentationCommentLinePrefix
 	}
 

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.xtend
@@ -52,14 +52,14 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 	}
 
 	override isIncomplete() {
-		if (incomplete != null)
+		if (incomplete !== null)
 			return incomplete
 
 		return super.isIncomplete()
 	}
 
 	override getTextRange() {
-		if (textRange != null)
+		if (textRange !== null)
 			return textRange
 		return super.textRange
 	}
@@ -79,7 +79,7 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 			if (block.closing) {
 				val bracePair = block.bracePairForClosingBrace
 				val index = openingBlockIndex.get(bracePair).last
-				if (index != null) {
+				if (index !== null) {
 					openingBlockIndex.remove(bracePair, index)
 
 					group(stack, index, bracePair, block)
@@ -104,7 +104,7 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 			return
 
 		val groupBlock = children.createGroup
-		groupBlock.incomplete = closingBlock == null || closingBlock.elementType == TokenType.ERROR_ELEMENT
+		groupBlock.incomplete = closingBlock === null || closingBlock.elementType == TokenType.ERROR_ELEMENT
 
 		val enforceIndentToChildren = children.shouldEnforceIndentToChildren
 		groupBlock.indent = bracePair.getIndent(enforceIndentToChildren)
@@ -129,7 +129,7 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 			return true
 
 		val bracePair = children.head.bracePairForOpeningBrace
-		if (bracePair == null || !bracePair.structural)
+		if (bracePair === null || !bracePair.structural)
 			return true
 
 		return children.last.bracePairForClosingBrace != bracePair
@@ -148,7 +148,7 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 	}
 
 	override isLeaf() {
-		myNode.firstChildNode == null
+		myNode.firstChildNode === null
 	}
 
 	override getSpacing(Block child1, Block child2) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/highlighting/IdeaHighlightingAttributesProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/highlighting/IdeaHighlightingAttributesProvider.xtend
@@ -40,7 +40,7 @@ class IdeaHighlightingAttributesProvider {
 	Map<String, String> xtextStyle2xtextStyleRedirectMap
 	
 	protected def void initialize() {
-		if (attributesDescriptors == null) {
+		if (attributesDescriptors === null) {
 			attributesDescriptors = newArrayList
 			name2highlightInfoType = newHashMap
 			xtextStyle2xtextStyleRedirectMap = newHashMap

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/nodemodel/ASTNodeAwareNodeModelBuilder.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/nodemodel/ASTNodeAwareNodeModelBuilder.xtend
@@ -50,7 +50,7 @@ class ASTNodeAwareNodeModelBuilder extends NodeModelBuilder implements IASTNodeA
 	
 	protected def replaceAssociations(INode oldNode, INode newNode) {
 		val mapping = reverseNodesMapping.remove(oldNode)
-		if (mapping != null) {
+		if (mapping !== null) {
 			for (astNode : mapping) {
 				associate(astNode, newNode)
 			}
@@ -84,7 +84,7 @@ class ASTNodeAwareNodeModelBuilder extends NodeModelBuilder implements IASTNodeA
 				elementType.grammarElement
 			} else {
 				val tokenType = getUserData(TOKEN_TYPE_KEY)
-				if (tokenType != null) {
+				if (tokenType !== null) {
 					val tokenName = tokenType.toString
 					if (tokenName.lexerRule) {
 						val ruleName = tokenName.lexerRuleName

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AbstractPsiAntlrParser.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AbstractPsiAntlrParser.xtend
@@ -125,7 +125,7 @@ abstract class AbstractPsiAntlrParser extends Parser {
 
 	protected def void doneLeaf(Token matchedToken) {
 		val tokenType = psiInput.remapToken(null)
-		if (matchedToken == null) {
+		if (matchedToken === null) {
 			psiBuilder.mark.done(new GrammarAwareErrorElementType(tokenType))
 			return
 		}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AbstractXtextPsiParser.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AbstractXtextPsiParser.xtend
@@ -52,7 +52,7 @@ abstract class AbstractXtextPsiParser implements PsiParser {
 		var rootMarker = builder.mark
 
 		val entryRuleName = root.entryRuleName
-		if (entryRuleName != null) {
+		if (entryRuleName !== null) {
 			parser.parse(entryRuleName)
 		} else {
 			parser.parse
@@ -77,7 +77,7 @@ abstract class AbstractXtextPsiParser implements PsiParser {
 		val tokenSource = builder.createTokenSource
 		new PsiXtextTokenStream(builder, tokenSource, tokenDefProvider) => [
 			val lookAhead = builder.getUserData(IASTNodeAwareNodeModelBuilder.LOOK_AHEAD_KEY)
-			if (lookAhead != null) {
+			if (lookAhead !== null) {
 				initCurrentLookAhead(lookAhead)
 			}
 			initialHiddenTokens = initialHiddenTokens

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AntlrDelegatingIdeaLexer.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/AntlrDelegatingIdeaLexer.xtend
@@ -46,7 +46,7 @@ class AntlrDelegatingIdeaLexer extends LexerBase {
 
 	override IElementType getTokenType() {
 		locateToken
-		if (token == null) {
+		if (token === null) {
 			return null
 		}
 		val int type = token.getType();
@@ -82,7 +82,7 @@ class AntlrDelegatingIdeaLexer extends LexerBase {
 	}
 
 	def void locateToken() {
-		if (token == null) {
+		if (token === null) {
 			try {
 				token = tokenSource.nextToken as CommonToken
 			} catch (Exception e) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/PsiXtextTokenStream.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/parser/PsiXtextTokenStream.xtend
@@ -43,7 +43,7 @@ class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStream {
 	}
 	
 	override reportError(()=>String reporter) {
-		if (errorMessage == null) {
+		if (errorMessage === null) {
 			errorMessage = reporter.apply
 		}
 	}
@@ -58,7 +58,7 @@ class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStream {
 		while(!builder.eof) {
 			consume
 		}
-		if (errorMessage != null) {
+		if (errorMessage !== null) {
 			builder.error(errorMessage)
 			errorMessage = null
 		}
@@ -87,7 +87,7 @@ class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStream {
 		val token = get(builder.rawTokenIndex)
 		val hidden = token.channel == BaseRecognizer.HIDDEN
 		
-		val currentTokenType = if (tokenType == null) builder.tokenType else tokenType
+		val currentTokenType = if (tokenType === null) builder.tokenType else tokenType
 		builder.remapCurrentToken(
 			new CreateElementType(currentTokenType) [
 				putUserData(IASTNodeAwareNodeModelBuilder.HIDDEN_KEY, hidden)
@@ -95,7 +95,7 @@ class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStream {
 		)
 		
 		val errorMessage = token.errorMessage
-		if (errorMessage != null) {
+		if (errorMessage !== null) {
 			val errorMarker = builder.mark
 			builder.advanceLexer
 			errorMarker.error(errorMessage)
@@ -105,7 +105,7 @@ class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStream {
 	}
 	
 	protected def String getErrorMessage(Token token) {
-		if (token.channel != BaseRecognizer.HIDDEN && errorMessage != null) {
+		if (token.channel != BaseRecognizer.HIDDEN && errorMessage !== null) {
 			val result = errorMessage
 			errorMessage = null
 			return result

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/pom/AbstractXtextPomDeclarationSearcher.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/pom/AbstractXtextPomDeclarationSearcher.xtend
@@ -29,7 +29,7 @@ abstract class AbstractXtextPomDeclarationSearcher extends PomDeclarationSearche
 		}
 		if (element instanceof PsiNamedEObject) {
 			val nameIdentifierRange = element.nameIdentifier?.textRange
-			if (nameIdentifierRange != null) {
+			if (nameIdentifierRange !== null) {
 				val offsetInDocument = element.textRange.startOffset + offsetInElement
 				if (nameIdentifierRange.contains(offsetInDocument)) {
 					consumer.consume(element)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/presentation/DefaultItemPresentationProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/presentation/DefaultItemPresentationProvider.xtend
@@ -60,7 +60,7 @@ class DefaultItemPresentationProvider implements ItemPresentationProvider {
 	
 	def dispatch String text(EObject element) {
 		val labelFeature = element.eClass.labelFeature
-		if (labelFeature != null) {
+		if (labelFeature !== null) {
 			element.eGet(labelFeature)?.toString
 		}
 	}
@@ -71,7 +71,7 @@ class DefaultItemPresentationProvider implements ItemPresentationProvider {
 			if (!eAttribute.isMany() && eAttribute.getEType().getInstanceClass() != FeatureMap.Entry) {
 				if ("name".equalsIgnoreCase(eAttribute.getName())) {
 					return eAttribute
-				} else if (result == null) {
+				} else if (result === null) {
 					result = eAttribute
 				} else if (eAttribute.getEAttributeType().getInstanceClass() == String &&
 					result.getEAttributeType().getInstanceClass() != String) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/refactoring/NullNamesValidator.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/refactoring/NullNamesValidator.xtend
@@ -13,7 +13,7 @@ import com.intellij.openapi.project.Project
 class NullNamesValidator implements NamesValidator {
 	
 	override isIdentifier(String name, Project project) {
-		name != null
+		name !== null
 	}
 	
 	override isKeyword(String name, Project project) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaClasspathURIResolver.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaClasspathURIResolver.xtend
@@ -35,7 +35,7 @@ class IdeaClasspathURIResolver implements IClasspathUriResolver {
 			val files = FilenameIndex.getFilesByName(module.project, classpathUri.lastSegment, scope)
 			for (file : files) {
 				val vf = XtextPsiUtils.findVirtualFile(file)
-				if (vf != null && vf.exists) {
+				if (vf !== null && vf.exists) {
 					val uri = VirtualFileURIUtil.getURI(vf);
 					if (uri.toString.endsWith(classpathUri.path)) {
 						return uri

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaEncodingProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaEncodingProvider.xtend
@@ -24,7 +24,7 @@ class IdeaEncodingProvider implements IEncodingProvider {
 	override getEncoding(URI uri) {
 		val fileManager = ApplicationManager.getApplication().getComponent(VirtualFileManager);
 		// fall back when no file manager exists (parsing tests)
-		if (fileManager == null)
+		if (fileManager === null)
 			return new IEncodingProvider.Runtime().getEncoding(uri)
 
 		return uri.charset?.name ?: 'UTF-8'

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaResourceDescriptionsProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaResourceDescriptionsProvider.xtend
@@ -18,7 +18,7 @@ class IdeaResourceDescriptionsProvider implements IResourceDescriptionsProvider 
 	
 	override getResourceDescriptions(ResourceSet resourceSet) {
 		val index = ChunkedResourceDescriptions.findInEmfObject(resourceSet)
-		if (index != null)
+		if (index !== null)
 			return index
 		throw new IllegalStateException("No index installed.")
 	}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaResourceSetProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/IdeaResourceSetProvider.xtend
@@ -114,7 +114,7 @@ class IdeaResourceSetProvider {
 				}
 				for (uri : localDeleted) {
 					val file = getVirtualFile(uri)
-					if (file != null && file.exists)
+					if (file !== null && file.exists)
 						file.delete(requestor)
 				}
 			]
@@ -132,12 +132,12 @@ class IdeaResourceSetProvider {
 				return new ByteArrayInputStream(writtenContents.get(uri).content)
 			}
 			val virtualFile = getVirtualFile(uri)
-			if (virtualFile == null) {
+			if (virtualFile === null) {
 				throw new FileNotFoundException("Couldn't find virtual file for " + uri)
 			}
 
 			val cachedDocument = FileDocumentManager.instance.getCachedDocument(virtualFile)
-			if (cachedDocument != null) {
+			if (cachedDocument !== null) {
 				return new LazyStringInputStream(cachedDocument.text, virtualFile.charset)
 			}
 
@@ -177,7 +177,7 @@ class IdeaResourceSetProvider {
 			if (writtenContents.containsKey(uri)) {
 				return true
 			}
-			if (uri.folderDescriptor != null) {
+			if (uri.folderDescriptor !== null) {
 				return true
 			}
 			return getVirtualFile(uri)?.exists
@@ -188,11 +188,11 @@ class IdeaResourceSetProvider {
 				return emptyMap
 
 			val requestedAttributes = options.get(OPTION_REQUESTED_ATTRIBUTES) as Set<String>
-			if (requestedAttributes == null || requestedAttributes.empty)
+			if (requestedAttributes === null || requestedAttributes.empty)
 				return emptyMap
 
 			val fileDescriptor = writtenContents.get(uri)
-			if (fileDescriptor != null) {
+			if (fileDescriptor !== null) {
 				val attributes = newHashMap
 				if (requestedAttributes.contains(ATTRIBUTE_DIRECTORY))
 					attributes.put(ATTRIBUTE_DIRECTORY, false)
@@ -202,7 +202,7 @@ class IdeaResourceSetProvider {
 			}
 
 			val folderDescriptor = uri.folderDescriptor
-			if (folderDescriptor != null) {
+			if (folderDescriptor !== null) {
 				val attributes = newHashMap
 				if (requestedAttributes.contains(ATTRIBUTE_DIRECTORY))
 					attributes.put(ATTRIBUTE_DIRECTORY, true)
@@ -212,7 +212,7 @@ class IdeaResourceSetProvider {
 			}
 
 			val file = uri.virtualFile
-			if (file != null) {
+			if (file !== null) {
 				val attributes = newHashMap
 				if (requestedAttributes.contains(ATTRIBUTE_DIRECTORY))
 					attributes.put(ATTRIBUTE_DIRECTORY, file.directory)
@@ -236,7 +236,7 @@ class IdeaResourceSetProvider {
 
 		def getChildren(URI uri) {
 			val file = uri.virtualFile
-			val children = if (file != null)
+			val children = if (file !== null)
 					file.children.map[URI].toSet
 				else
 					newLinkedHashSet

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/PsiToEcoreTransformationContext.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/PsiToEcoreTransformationContext.xtend
@@ -125,13 +125,13 @@ class PsiToEcoreTransformationContext {
 	}
 	
 	def merge(PsiToEcoreTransformationContext childTransformationContext, boolean forced) {
-		if (current == null || forced) {
+		if (current === null || forced) {
 			current = childTransformationContext.current
 		}
-		if (datatypeRuleToken != null && childTransformationContext.datatypeRuleToken != null) {
+		if (datatypeRuleToken !== null && childTransformationContext.datatypeRuleToken !== null) {
 			datatypeRuleToken.merge(childTransformationContext.datatypeRuleToken)
 		}
-		if (enumerator == null) {
+		if (enumerator === null) {
 			enumerator = childTransformationContext.enumerator
 		}
 		this
@@ -173,7 +173,7 @@ class PsiToEcoreTransformationContext {
 	}
 	
 	private def ensureModelElementCreated(EObject grammarElement, ICompositeNode currentNode) {
-		if (grammarElement == null) {
+		if (grammarElement === null) {
 			return false
 		}
 		if (grammarElement instanceof Action) {
@@ -183,7 +183,7 @@ class PsiToEcoreTransformationContext {
 		}
 		if (!grammarElement.assigned) {
 			if (grammarElement.isEObjectFragmentRuleCall) {
-				if (current != null) {
+				if (current !== null) {
 					return true
 				}
 				val classifier = grammarElement.containingParserRule.type.classifier
@@ -206,7 +206,7 @@ class PsiToEcoreTransformationContext {
 			}
 			return false
 		}
-		if (current != null) {
+		if (current !== null) {
 			return true
 		}
 		val classifier = grammarElement.containingParserRule.type.classifier
@@ -237,7 +237,7 @@ class PsiToEcoreTransformationContext {
 	}
 
 	protected def void mergeDatatypeRuleToken(LeafElement it) {
-		if (datatypeRuleToken != null) {
+		if (datatypeRuleToken !== null) {
 			datatypeRuleToken.merge(new AntlrDatatypeRuleToken => [ token |
 				token.text = text
 				token.startOffset = startOffset
@@ -246,7 +246,7 @@ class PsiToEcoreTransformationContext {
 	}
 
 	def assign(EObject value, Action action) {
-		if (action.feature != null) {
+		if (action.feature !== null) {
 			current.assign(action.operator, action.feature, value, null, currentNode)
 		}
 	}
@@ -275,7 +275,7 @@ class PsiToEcoreTransformationContext {
 	protected def associateWithSemanticElement(ICompositeNode node) {
 		node.associateWithSemanticElement(current)
 		val astNode = reverseNodesMapping.get(node)?.last
-		if (astNode != null) {
+		if (astNode !== null) {
 			psiModelAssociator.associate(current)[|astNode.psi]
 		}
 	}
@@ -342,7 +342,7 @@ class PsiToEcoreTransformationContext {
 	}
 
 	protected def appendError(INode node, SyntaxErrorMessage error) {
-		if (node.syntaxErrorMessage == null) {
+		if (node.syntaxErrorMessage === null) {
 			val newNode = node.syntaxError = error
 			if (node == currentNode)
 				currentNode = newNode as ICompositeNode
@@ -380,7 +380,7 @@ class ErrorContext {
 	val PsiToEcoreTransformationContext transformationContext
 
 	def getCurrentContext() {
-		if (currentNode != null)
+		if (currentNode !== null)
 			currentNode.semanticElement
 	}
 
@@ -397,11 +397,11 @@ class ValueConverterErrorContext extends ErrorContext implements ISyntaxErrorMes
 
 	override getDefaultMessage() {
 		val cause = valueConverterException.cause as Exception
-		var result = if(cause != null) cause.message else valueConverterException.message
-		if (result == null)
+		var result = if(cause !== null) cause.message else valueConverterException.message
+		if (result === null)
 			result = valueConverterException.message
-		if (result == null)
-			result == if(cause != null) cause.class.simpleName else valueConverterException.class.simpleName
+		if (result === null)
+			result == if(cause !== null) cause.class.simpleName else valueConverterException.class.simpleName
 		result
 	}
 

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/PsiToEcoreTransformator.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/PsiToEcoreTransformator.xtend
@@ -317,7 +317,7 @@ class PsiToEcoreTransformator implements IParser {
 				transformChildren(childTransformationContext).sync
 				if (ruleCall.ensureModelElementCreated) {
 					val child = if (rule instanceof ParserRule) childTransformationContext.current else childTransformationContext.enumerator 
-					if (child != null) {
+					if (child !== null) {
 						assign(child, ruleCall, rule.qualifiedName)
 					}
 				}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/VirtualFileURIUtil.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/VirtualFileURIUtil.xtend
@@ -48,7 +48,7 @@ class VirtualFileURIUtil {
 	
 	private def static VirtualFile getOrCreateFile(URI uri, boolean isDirectory) {
 		val file = getVirtualFile(uri)
-		if (file != null) {
+		if (file !== null) {
 			return file
 		}
 		if (uri.segmentCount==0) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/AbstractStructureViewTreeElement.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/AbstractStructureViewTreeElement.xtend
@@ -38,19 +38,19 @@ abstract class AbstractStructureViewTreeElement implements ModifiableStructureVi
 		if (leaf) {
 			return emptyList
 		}
-		if (children == null) {
+		if (children === null) {
 			children = newArrayList
 			structureViewTreeElementProvider.buildChildren(this)
 		}
-		if (children == null) {
+		if (children === null) {
 			return emptyList
 		} 
 		children
 	}
 	
 	override addChild(StructureViewTreeElement child) {
-		if (child != null) {
-			if (children == null) {
+		if (child !== null) {
+			if (children === null) {
 				children = newArrayList
 			}
 			leaf = false
@@ -63,7 +63,7 @@ abstract class AbstractStructureViewTreeElement implements ModifiableStructureVi
 	override addChildren(Iterable<StructureViewTreeElement> children) {
 		val notNullChildren = children.filterNull
 		if (!notNullChildren.empty) {
-			if (this.children == null) {
+			if (this.children === null) {
 				this.children = newArrayList
 			}
 			leaf = false
@@ -102,7 +102,7 @@ abstract class AbstractStructureViewTreeElement implements ModifiableStructureVi
 	protected def getNavigationElement() {
 		try {
 			val element = internalNavigationElement
-			if (element != null && element.valid) {
+			if (element !== null && element.valid) {
 				element
 			}
 		} catch (Exception e) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/AlphaSorter.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/AlphaSorter.xtend
@@ -23,7 +23,7 @@ class AlphaSorter implements Sorter {
 	Comparator<TreeElement> comparator
 
 	override isVisible() {
-		comparator != null
+		comparator !== null
 	}
 
 	override getName() {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/DefaultStructureViewTreeElementProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/DefaultStructureViewTreeElementProvider.xtend
@@ -39,12 +39,12 @@ class DefaultStructureViewTreeElementProvider implements IStructureViewTreeEleme
 
 	def dispatch void buildChildren(XtextFileTreeElement it) {
 		val modelElement = element.resource.contents.head
-		if (modelElement == null) {
+		if (modelElement === null) {
 			return
 		}
 		val itemPresentation = modelElement.itemPresentation ?: new PresentationData
 		if (itemPresentation instanceof PresentationData)
-			if (itemPresentation.presentableText == null)
+			if (itemPresentation.presentableText === null)
 				itemPresentation.presentableText = modelElement.eResource.URI.trimFileExtension.lastSegment
 		addChild(
 			modelElement.createEObjectTreeElement(
@@ -81,7 +81,7 @@ class DefaultStructureViewTreeElementProvider implements IStructureViewTreeEleme
 
 	protected def createEObjectTreeElement(EObject modelElement, BaseXtextFile xtextFile, boolean leaf,
 		ItemPresentation itemPresentation) {
-		if (itemPresentation?.presentableText == null && leaf) {
+		if (itemPresentation?.presentableText === null && leaf) {
 			return null
 		}
 		objectTreeElementProvider.get => [ objectTreeElement |

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/XtextFileTreeElement.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/XtextFileTreeElement.xtend
@@ -30,7 +30,7 @@ class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> implements 
 	override getChildrenBase() {
 		children = null
 		structureViewTreeElementProvider.buildChildren(this)
-		if (children == null) {
+		if (children === null) {
 			return emptyList
 		}
 		children
@@ -41,8 +41,8 @@ class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> implements 
 	}
 
 	override addChild(StructureViewTreeElement child) {
-		if (child != null) {
-			if (children == null) {
+		if (child !== null) {
+			if (children === null) {
 				children = newArrayList
 			}
 			children += child
@@ -54,7 +54,7 @@ class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> implements 
 	override addChildren(Iterable<StructureViewTreeElement> children) {
 		val notNullChildren = children.filterNull
 		if (!notNullChildren.empty) {
-			if (this.children == null) {
+			if (this.children === null) {
 				this.children = newArrayList
 			}
 			this.children += notNullChildren

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/XtextFileTreeModel.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/structureview/XtextFileTreeModel.xtend
@@ -47,7 +47,7 @@ class XtextFileTreeModel extends TextEditorBasedStructureViewModel implements St
 		xtextFile.xtextLanguage.injectMembers(this)
 		sorters = newArrayList
 		val comparator = comparator
-		if (comparator != null) {
+		if (comparator !== null) {
 			sorters += new AlphaSorter => [
 				it.comparator = comparator
 			]

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceBasedGeneratedSourcesFilter.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceBasedGeneratedSourcesFilter.xtend
@@ -38,7 +38,7 @@ class TraceBasedGeneratedSourcesFilter extends GeneratedSourcesFilter {
 		// don't navigate to the original element on double click in project explorer
 		if (ApplicationManager.application.isDispatchThread) {
 			val focusOwner = IdeFocusManager.getInstance(element.project).focusOwner
-			if (focusOwner != null && focusOwner.class.name.startsWith(ProjectViewPane.name)) {
+			if (focusOwner !== null && focusOwner.class.name.startsWith(ProjectViewPane.name)) {
 				return emptyList
 			}
 		}

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.xtend
@@ -154,7 +154,7 @@ class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<VirtualFil
 			} else {
 				for (contentRoot : ModuleRootManager.getInstance(module).contentRoots) {
 					val result = contentRoot.findFileByRelativePath(outputFolder)
-					if (result != null)
+					if (result !== null)
 						return result
 				}
 				return null

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/VirtualFileInProject.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/VirtualFileInProject.xtend
@@ -23,7 +23,7 @@ class VirtualFileInProject {
 	
 	def static VirtualFileInProject forPsiElement(PsiElement element) {
 		val virtualFile = XtextPsiUtils.findVirtualFile(element)
-		if (virtualFile == null)
+		if (virtualFile === null)
 			return null
 
 		return new VirtualFileInProject(virtualFile, element.project)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/GlobalPsiModelAssociations.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/GlobalPsiModelAssociations.xtend
@@ -28,7 +28,7 @@ class GlobalPsiModelAssociations implements IPsiModelAssociations {
 	IResourceServiceProvider.Registry resourceServiceProviderRegistry
 
 	override getEObject(PsiElement element) {
-		if (element == null) return null
+		if (element === null) return null
 
 		val containingFile = element.containingFile
 		if (containingFile instanceof BaseXtextFile) {
@@ -41,7 +41,7 @@ class GlobalPsiModelAssociations implements IPsiModelAssociations {
 	}
 
 	override getPsiElement(EObject object) {
-		if (object == null) return null
+		if (object === null) return null
 
 		val resourceURI = EcoreUtil.getURI(object).trimFragment
 		val resourceServiceProvider = resourceServiceProviderRegistry.getResourceServiceProvider(resourceURI)
@@ -50,7 +50,7 @@ class GlobalPsiModelAssociations implements IPsiModelAssociations {
 	}
 
 	override getPsiElement(IEObjectDescription objectDescription, Resource context) {
-		if (objectDescription == null || context == null) return null
+		if (objectDescription === null || context === null) return null
 		
 		val resourceURI = context.URI
 		val resourceServiceProvider = resourceServiceProviderRegistry.getResourceServiceProvider(resourceURI)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/XtextPsiExtensions.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/XtextPsiExtensions.xtend
@@ -30,7 +30,7 @@ class XtextPsiExtensions {
 	}
 	
 	def PsiElement findEObjectAssociatedPsiElement(PsiElement element) {
-		return element.findFirstParent(false)[associations.getEObject(it) != null]
+		return element.findFirstParent(false)[associations.getEObject(it) !== null]
 	}
 	
 	def EObject findEObject(PsiElement ctx) {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/XtextPsiUtils.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/XtextPsiUtils.xtend
@@ -28,7 +28,7 @@ class XtextPsiUtils {
 				return virtualFile 
 			}
 			return element.getViewProvider().getVirtualFile() 
-		} else if (element == null) {
+		} else if (element === null) {
 			return null
 		} else {
 			findVirtualFile(element.containingFile)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/PsiEObjectImpl.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/PsiEObjectImpl.xtend
@@ -122,14 +122,14 @@ class PsiEObjectImpl<PsiT extends PsiElement, T extends StubElement<PsiT>> exten
 			val textOffset = super.textOffset
 			
 			val rangeToHighlightInElement = reference.rangeToHighlightInElement
-			if (rangeToHighlightInElement != null)
+			if (rangeToHighlightInElement !== null)
 				return textOffset + rangeToHighlightInElement.startOffset
 				
 			return textOffset
 		}
 
 		val textRegion = significantTextRegion
-		if (textRegion != null)
+		if (textRegion !== null)
 			return textRegion.offset
 			 
 		return super.textOffset

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/PsiNamedEObjectImpl.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/PsiNamedEObjectImpl.xtend
@@ -37,7 +37,7 @@ class PsiNamedEObjectImpl<PsiE extends PsiNamedEObject, T extends PsiNamedEObjec
 
 	override getNameIdentifier() {
 		val nameNode = findNameNode
-		if (nameNode == null) {
+		if (nameNode === null) {
 			return null
 		}
 		new PsiEObjectIdentifierImpl(nameNode.psi)
@@ -45,7 +45,7 @@ class PsiNamedEObjectImpl<PsiE extends PsiNamedEObject, T extends PsiNamedEObjec
 
 	override getName() {
 		val stub = stub
-		if (stub != null) {
+		if (stub !== null) {
 			return stub.name
 		}
 		

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/XtextPsiReferenceImpl.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/psi/impl/XtextPsiReferenceImpl.xtend
@@ -116,7 +116,7 @@ class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> implements
 	override getVariants() {
 		ProgressIndicatorProvider.checkCanceled
 		var crossReferenceDescription = crossReferenceDescription
-		if (crossReferenceDescription == null) {
+		if (crossReferenceDescription === null) {
 			return emptyList
 		}
 		var variants = newArrayList
@@ -127,7 +127,7 @@ class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> implements
 			// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=481381
 			if (objectDescription.EObjectOrProxy.eIsProxy || objectDescription.EObjectOrProxy.eResource !== null) {
 				var element = objectDescription.getPsiElement(myElement.xtextFile.resource)
-				if (element != null) {
+				if (element !== null) {
 					variants +=
 						LookupElementBuilder.create(name).withTypeText(element.navigationElement.containingFile.name)
 				}
@@ -139,7 +139,7 @@ class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> implements
 	override resolve() {
 		ProgressIndicatorProvider.checkCanceled
 		var crossReferenceDescription = crossReferenceDescription
-		if (crossReferenceDescription == null) {
+		if (crossReferenceDescription === null) {
 			return null
 		}
 		var object = crossReferenceDescription.resolve

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/annotations/idea/completion/XbaseWithAnnotationsCompletionContributor.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/annotations/idea/completion/XbaseWithAnnotationsCompletionContributor.xtend
@@ -41,7 +41,7 @@ class XbaseWithAnnotationsCompletionContributor extends XbaseCompletionContribut
 			CompletionType.BASIC,
 			XAnnotationsPackage.Literals.XANNOTATION__VALUE
 		) [
-			val psiElement = $0.position.findFirstParent(false)[EObject != null]
+			val psiElement = $0.position.findFirstParent(false)[EObject !== null]
 			val annotation = psiElement.EObject.getContainerOfType(XAnnotation)
 			switch annotationType : annotation?.annotationType {
 				JvmAnnotationType case !annotationType.eIsProxy: {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/facet/XbaseFacetForm.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/facet/XbaseFacetForm.xtend
@@ -100,7 +100,7 @@ class XbaseFacetForm extends GeneratorFacetForm {
 	override setData(GeneratorConfigurationState data) {
 		super.setData(data)
 		if (data instanceof XbaseGeneratorConfigurationState) {
-			if (LanguageLevel.values.findFirst[it.name() === data.targetJavaVersion] != null) {
+			if (LanguageLevel.values.findFirst[it.name() === data.targetJavaVersion] !== null) {
 				targetJavaVersion.selectedItem = LanguageLevel.valueOf(data.targetJavaVersion)
 			} else {
 				targetJavaVersion.selectedItem = null
@@ -166,7 +166,7 @@ class XbaseFacetForm extends GeneratorFacetForm {
 
 			override protected LanguageLevel getDefaultLevel() {
 				var langLevel = llExt.languageLevel
-				if (langLevel == null) {
+				if (langLevel === null) {
 					langLevel = LanguageLevelProjectExtensionImpl.getInstanceImpl(module.project).getCurrentLevel()
 				}
 				return langLevel

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/facet/XbaseGeneratorConfigProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/facet/XbaseGeneratorConfigProvider.xtend
@@ -54,7 +54,7 @@ import static extension com.intellij.openapi.module.EffectiveLanguageLevelUtil.*
 	protected def getTargetJavaVersion(XbaseGeneratorConfigurationState state, Module module) {
 		val version = state.targetJavaVersion
 		val languageLevel = 
-			if(version == null || version.equals('Module default')) {
+			if(version === null || version.equals('Module default')) {
 				val Computable<LanguageLevel> action = [  
 					module.effectiveLanguageLevel
 				]

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/findusages/JvmElementAwareReferenceSearcher.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/findusages/JvmElementAwareReferenceSearcher.xtend
@@ -61,7 +61,7 @@ class JvmElementAwareReferenceSearcher implements IReferenceSearcher {
 	}
 
 	protected def void accept(Set<String> words, String word) {
-		if (word != null)
+		if (word !== null)
 			words += word
 	}
 
@@ -81,10 +81,10 @@ class JvmElementAwareReferenceSearcher implements IReferenceSearcher {
 		acceptor.apply(jvmElement.simpleName)
 		
 		val simpleOperator = QualifiedName.create(jvmElement.simpleName).operator
-		if (simpleOperator != null) {
+		if (simpleOperator !== null) {
 			acceptor.apply(simpleOperator.toString)
 			val compoundOperator = simpleOperator.compoundOperator
-			if (compoundOperator != null)
+			if (compoundOperator !== null)
 				acceptor.apply(compoundOperator.toString)
 		} else
 			acceptor.apply(jvmElement.propertyName)

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/findusages/XbaseWordsScanner.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/findusages/XbaseWordsScanner.xtend
@@ -37,7 +37,7 @@ class XbaseWordsScanner implements WordsScanner {
 
 	override void processWords(CharSequence fileText, Processor<WordOccurrence> processor) {
 		lexer.start(fileText)
-		while (lexer.tokenType != null) {
+		while (lexer.tokenType !== null) {
 			scanOperator(processor)
 			scanWords(processor)
 			lexer.advance
@@ -64,7 +64,7 @@ class XbaseWordsScanner implements WordsScanner {
 	}
 
 	protected def void scanWords(Processor<WordOccurrence> processor) {
-		if (lexer.tokenType == null)
+		if (lexer.tokenType === null)
 			return;
 
 		val kind = occurrenceKind

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/formatting/XbaseBlockFactory.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/formatting/XbaseBlockFactory.xtend
@@ -53,7 +53,7 @@ class XbaseBlockFactory extends DefaultBlockFactory {
 	}
 
 	protected override isContinuation(EObject grammarElement) {
-		if(grammarElement == null) return false
+		if(grammarElement === null) return false
 
 		switch grammarElement {
 			case XAssignmentAccess.XAssignmentAction_0_0,
@@ -78,7 +78,7 @@ class XbaseBlockFactory extends DefaultBlockFactory {
 	}
 
 	protected override isStructural(EObject grammarElement) {
-		if(grammarElement == null) return false
+		if(grammarElement === null) return false
 
 		switch grammarElement {
 			case XIfExpressionAccess.thenXExpressionParserRuleCall_5_0,

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/formatting/XbaseChildAttributesProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/formatting/XbaseChildAttributesProvider.xtend
@@ -24,7 +24,7 @@ class XbaseChildAttributesProvider extends DefaultChildAttributesProvider {
 	extension XbaseGrammarAccess
 
 	protected override getIndentAfter(EObject grammarElement) {
-		if (grammarElement == null)
+		if (grammarElement === null)
 			return null
 
 		switch grammarElement {

--- a/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/presentation/XbaseItemPresentationProvider.xtend
+++ b/org.eclipse.xtext.idea/src/org/eclipse/xtext/xbase/idea/presentation/XbaseItemPresentationProvider.xtend
@@ -92,14 +92,14 @@ class XbaseItemPresentationProvider extends DefaultItemPresentationProvider {
 
 	def dispatch text(JvmFormalParameter parameter) {
 		val parameterType = parameter.parameterType
-		if (parameterType == null)
+		if (parameterType === null)
 			parameter.name
 		else
 			parameterType.getSimpleName + " " + parameter.name
 	}
 
 	def dispatch text(XImportDeclaration it) 
-		'''«importedTypeName»«IF wildcard».*«ELSEIF memberName != null».«memberName»«ENDIF»'''
+		'''«importedTypeName»«IF wildcard».*«ELSEIF memberName !== null».«memberName»«ENDIF»'''
 
 	def dispatch text(XImportSection element) {
 		'import declarations'
@@ -108,7 +108,7 @@ class XbaseItemPresentationProvider extends DefaultItemPresentationProvider {
 	def dispatch text(XVariableDeclaration variableDeclaration) {
 		val resolvedTypes = typeResolver.resolveTypes(variableDeclaration)
 		val type = resolvedTypes.getActualType(variableDeclaration as JvmIdentifiableElement)
-		if (type != null)
+		if (type !== null)
 			type.humanReadableName + " " + variableDeclaration.name
 		else 
 			variableDeclaration.name
@@ -123,7 +123,7 @@ class XbaseItemPresentationProvider extends DefaultItemPresentationProvider {
 				null
 			}
 		val owner = new StandardTypeReferenceOwner(services, element);
-		val returnTypeString = if (returnType == null) {
+		val returnTypeString = if (returnType === null) {
 				"void"
 			} else {
 				owner.toLightweightTypeReference(returnType).humanReadableName

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/BuildProgressReporter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/BuildProgressReporter.java
@@ -132,7 +132,7 @@ public class BuildProgressReporter implements BuildRequest.IPostValidationCallba
     boolean _xblockexpression = false;
     {
       final Application application = ApplicationManager.getApplication();
-      _xblockexpression = (Objects.equal(application, null) || application.isUnitTestMode());
+      _xblockexpression = ((application == null) || application.isUnitTestMode());
     }
     return _xblockexpression;
   }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/IdeaOutputConfigurationProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/IdeaOutputConfigurationProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.build;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.intellij.facet.Facet;
@@ -64,8 +63,7 @@ public class IdeaOutputConfigurationProvider implements IContextualOutputConfigu
   
   public Set<OutputConfiguration> getOutputConfigurations(final Module module) {
     final Facet<? extends AbstractFacetConfiguration> facet = this.facetProvider.getFacet(module);
-    boolean _notEquals = (!Objects.equal(facet, null));
-    if (_notEquals) {
+    if ((facet != null)) {
       AbstractFacetConfiguration _configuration = facet.getConfiguration();
       final GeneratorConfigurationState generatorConf = _configuration.getState();
       final OutputConfiguration defOut = new OutputConfiguration(IFileSystemAccess.DEFAULT_OUTPUT);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.java
@@ -234,8 +234,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
         FileDocumentManager _instance = FileDocumentManager.getInstance();
         Document _document = event.getDocument();
         VirtualFile file = _instance.getFile(_document);
-        boolean _notEquals = (!Objects.equal(file, null));
-        if (_notEquals) {
+        if ((file != null)) {
           XtextAutoBuilderComponent.this.fileModified(file);
         } else {
           Document _document_1 = event.getDocument();
@@ -528,8 +527,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
     this.chunkedResourceDescriptions.removeContainer(_name);
     String _name_1 = module.getName();
     final Source2GeneratedMapping before = this.moduleName2GeneratedMapping.remove(_name_1);
-    boolean _notEquals = (!Objects.equal(before, null));
-    if (_notEquals) {
+    if ((before != null)) {
       List<URI> _allGenerated = before.getAllGenerated();
       this.safeDeleteUris(_allGenerated);
     }
@@ -632,7 +630,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
       }
       return true;
     }
-    return (Objects.equal(file, null) || file.isDirectory());
+    return ((file == null) || file.isDirectory());
   }
   
   protected boolean isLoaded() {
@@ -898,14 +896,11 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
   public Function1<URI, IResourceServiceProvider> getServiceProviderProvider(final Module module) {
     final Function1<URI, IResourceServiceProvider> _function = (URI it) -> {
       final IResourceServiceProvider serviceProvider = this.resourceServiceProviderRegistry.getResourceServiceProvider(it);
-      boolean _notEquals = (!Objects.equal(serviceProvider, null));
-      if (_notEquals) {
+      if ((serviceProvider != null)) {
         final FacetProvider facetProvider = serviceProvider.<FacetProvider>get(FacetProvider.class);
-        boolean _notEquals_1 = (!Objects.equal(facetProvider, null));
-        if (_notEquals_1) {
+        if ((facetProvider != null)) {
           final Facet<? extends AbstractFacetConfiguration> facet = facetProvider.getFacet(module);
-          boolean _notEquals_2 = (!Objects.equal(facet, null));
-          if (_notEquals_2) {
+          if ((facet != null)) {
             return serviceProvider;
           }
         }
@@ -945,7 +940,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
                   _source=fileMappings.getSource(uri);
                 }
                 final List<URI> sourceUris = _source;
-                if (((!Objects.equal(sourceUris, null)) && (!sourceUris.isEmpty()))) {
+                if (((sourceUris != null) && (!sourceUris.isEmpty()))) {
                   for (final URI sourceUri : sourceUris) {
                     this.consistentAdd(sourceUri, changedUris, deletedUris);
                   }
@@ -974,7 +969,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
                   _source=fileMappings.getSource(uri_1);
                 }
                 final List<URI> sourceUris = _source;
-                if (((!Objects.equal(sourceUris, null)) && (!sourceUris.isEmpty()))) {
+                if (((sourceUris != null) && (!sourceUris.isEmpty()))) {
                   for (final URI sourceUri : sourceUris) {
                     boolean _contains = deletedUris.contains(sourceUri);
                     boolean _not = (!_contains);
@@ -1061,13 +1056,11 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
   }
   
   protected Module findModule(final VirtualFile file, final ProjectFileIndex fileIndex) {
-    boolean _equals = Objects.equal(file, null);
-    if (_equals) {
+    if ((file == null)) {
       return null;
     }
     final Module module = fileIndex.getModuleForFile(file, true);
-    boolean _notEquals = (!Objects.equal(module, null));
-    if (_notEquals) {
+    if ((module != null)) {
       return module;
     }
     VirtualFile _parent = file.getParent();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/DerivedMemberAwarePsiModelAssociations.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/DerivedMemberAwarePsiModelAssociations.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.common.types;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.intellij.psi.PsiElement;
@@ -30,15 +29,13 @@ public class DerivedMemberAwarePsiModelAssociations extends PsiModelAssociations
   public PsiElement getPsiElement(final EObject object) {
     PsiElement _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(object, null);
-      if (_equals) {
+      if ((object == null)) {
         return null;
       }
       EObject _convertToSource = this.convertToSource(object);
       final PsiElement psiElement = super.getPsiElement(_convertToSource);
       PsiElement _xifexpression = null;
-      boolean _equals_1 = Objects.equal(psiElement, null);
-      if (_equals_1) {
+      if ((psiElement == null)) {
         EObject _eContainer = object.eContainer();
         _xifexpression = this.getPsiElement(_eContainer);
       } else {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/PsiBasedTypeFactory.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/PsiBasedTypeFactory.java
@@ -167,8 +167,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
           {
             final StringBuilder buffer = new StringBuilder(100);
             final String packageName = this.getPackageName(psiClass);
-            boolean _notEquals = (!Objects.equal(packageName, null));
-            if (_notEquals) {
+            if ((packageName != null)) {
               StringBuilder _append = buffer.append(packageName);
               _append.append(".");
             }
@@ -261,8 +260,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
     for (final PsiAnnotation annotation : _annotations) {
       {
         final JvmAnnotationReference annotationReference = this.createAnnotationReference(annotation);
-        boolean _notEquals = (!Objects.equal(annotationReference, null));
-        if (_notEquals) {
+        if ((annotationReference != null)) {
           EList<JvmAnnotationReference> _annotations_1 = it.getAnnotations();
           this.<JvmAnnotationReference>addUnique(_annotations_1, annotationReference);
         }
@@ -376,8 +374,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
         JvmField _createJvmField = this._typesFactory.createJvmField();
         final Procedure1<JvmField> _function = (JvmField it) -> {
           final Object value = this.getConstantValue(field);
-          boolean _notEquals = (!Objects.equal(value, null));
-          if (_notEquals) {
+          if ((value != null)) {
             it.setConstant(true);
             it.setConstantValue(value);
           } else {
@@ -559,8 +556,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
       PsiAnnotationMemberValue _defaultValue = ((PsiAnnotationMethod)method).getDefaultValue();
       Project _project = ((PsiAnnotationMethod)method).getProject();
       final Object defaultValue = this.computeAnnotationValue(_defaultValue, _project);
-      boolean _notEquals = (!Objects.equal(defaultValue, null));
-      if (_notEquals) {
+      if ((defaultValue != null)) {
         final JvmAnnotationValue annotationValue = this.createAnnotationValue(defaultValue, method);
         operation.setDefaultValue(annotationValue);
         annotationValue.setOperation(operation);
@@ -694,8 +690,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
       if (it instanceof JvmAnnotationAnnotationValue) {
         _matched=true;
         final JvmAnnotationReference annotationReference = this.createAnnotationReference(((PsiAnnotation) value));
-        boolean _notEquals = (!Objects.equal(annotationReference, null));
-        if (_notEquals) {
+        if ((annotationReference != null)) {
           EList<JvmAnnotationReference> _values = ((JvmAnnotationAnnotationValue)it).getValues();
           this.<JvmAnnotationReference>addUnique(_values, annotationReference);
         }
@@ -1328,7 +1323,7 @@ public class PsiBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
   }
   
   protected boolean isInnerTypeReference(final PsiClass psiClass) {
-    return ((!Objects.equal(psiClass.getContainingClass(), null)) && (!psiClass.hasModifierProperty(PsiModifier.STATIC)));
+    return ((psiClass.getContainingClass() != null) && (!psiClass.hasModifierProperty(PsiModifier.STATIC)));
   }
   
   protected JvmTypeReference _createTypeArgument(final PsiType type) {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/StubJvmTypeProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/StubJvmTypeProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.common.types;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
@@ -94,11 +93,11 @@ public class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
     JvmType _xblockexpression = null;
     {
       JvmType result = this.doFindTypeByName(name, false);
-      if (((!Objects.equal(result, null)) || this.isBinaryNestedTypeDelimiter(name, binaryNestedTypeDelimiter))) {
+      if (((result != null) || this.isBinaryNestedTypeDelimiter(name, binaryNestedTypeDelimiter))) {
         return result;
       }
       final AbstractJvmTypeProvider.ClassNameVariants nameVariants = new AbstractJvmTypeProvider.ClassNameVariants(name);
-      while ((Objects.equal(result, null) && nameVariants.hasNext())) {
+      while (((result == null) && nameVariants.hasNext())) {
         {
           final String nextVariant = nameVariants.next();
           JvmType _doFindTypeByName = this.doFindTypeByName(nextVariant, true);
@@ -180,13 +179,11 @@ public class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
       try {
         ResourceSet _resourceSet_1 = this.getResourceSet();
         final Resource existing = _resourceSet_1.getResource(resourceURI, false);
-        boolean _notEquals = (!Objects.equal(existing, null));
-        if (_notEquals) {
+        if ((existing != null)) {
           return this.findType(existing, fragment, traverseNestedTypes);
         }
         final IMirror mirror = this.createMirror(resourceURI);
-        boolean _equals = Objects.equal(mirror, null);
-        if (_equals) {
+        if ((mirror == null)) {
           return null;
         }
         final TypeResource resource = this.doCreateResource(resourceURI);
@@ -214,7 +211,7 @@ public class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
     final Computable<JvmType> _function = () -> {
       EObject _eObject = resource.getEObject(fragment);
       final JvmType result = ((JvmType) _eObject);
-      if (((!Objects.equal(result, null)) || (!traverseNestedTypes))) {
+      if (((result != null) || (!traverseNestedTypes))) {
         return result;
       }
       EList<EObject> _contents = resource.getContents();
@@ -244,7 +241,7 @@ public class StubJvmTypeProvider extends AbstractRuntimeJvmTypeProvider {
           Project _project = this.module.getProject();
           JavaPsiFacade _instance = JavaPsiFacade.getInstance(_project);
           final PsiClass psiClass = _instance.findClass(name, this.searchScope);
-          if ((Objects.equal(psiClass, null) || (!Objects.equal(psiClass.getContainingClass(), null)))) {
+          if (((psiClass == null) || (psiClass.getContainingClass() != null))) {
             return null;
           }
           _xblockexpression = new PsiClassMirror(psiClass, this.psiClassFactory);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/StubURIHelper.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/common/types/StubURIHelper.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.common.types;
 
-import com.google.common.base.Objects;
 import com.intellij.psi.PsiArrayType;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
@@ -188,8 +187,7 @@ public class StubURIHelper implements URIHelperConstants {
       }
       final PsiClass containingClass = psiClass.getContainingClass();
       StringBuilder _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(containingClass, null));
-      if (_notEquals) {
+      if ((containingClass != null)) {
         _xifexpression = this.appendClassResourceURI(builder, containingClass);
       } else {
         StringBuilder _append = builder.append(URIHelperConstants.OBJECTS);
@@ -264,8 +262,7 @@ public class StubURIHelper implements URIHelperConstants {
       return this.appendTypeParameterFragment(builder, ((PsiTypeParameter)psiClass));
     }
     final PsiClass containingClass = psiClass.getContainingClass();
-    boolean _equals = Objects.equal(containingClass, null);
-    if (_equals) {
+    if ((containingClass == null)) {
       String _qualifiedName = psiClass.getQualifiedName();
       return builder.append(_qualifiedName);
     } else {
@@ -342,8 +339,7 @@ public class StubURIHelper implements URIHelperConstants {
             _switchResult_1 = builder.append(_name);
           }
           if (!_matched_1) {
-            boolean _notEquals = (!Objects.equal(resolved, null));
-            if (_notEquals) {
+            if ((resolved != null)) {
               _matched_1=true;
               _switchResult_1 = this.appendTypeName(builder, resolved);
             }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.java
@@ -250,8 +250,8 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
     final Procedure1<CompletionResult> filteredConsumer = _function;
     CompletionService _completionService = CompletionService.getCompletionService();
     final CompletionResultSet filteredResult = _completionService.createResultSet(parameters, new Consumer<CompletionResult>() {
-        public void consume(CompletionResult arg0) {
-          filteredConsumer.apply(arg0);
+        public void consume(CompletionResult t) {
+          filteredConsumer.apply(t);
         }
     }, this);
     this.createMatcherBasedProposals(parameters, filteredResult);
@@ -272,8 +272,7 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
     CompletionType _completionType = parameters.getCompletionType();
     Multimap<TokenSet, CompletionProvider<CompletionParameters>> _get = this.myContributors.get(_completionType);
     final Collection<CompletionProvider<CompletionParameters>> providers = _get.get(tokenSet);
-    boolean _equals = Objects.equal(providers, null);
-    if (_equals) {
+    if ((providers == null)) {
       return;
     }
     final HashSet<CompletionProvider<CompletionParameters>> calledProviders = CollectionLiterals.<CompletionProvider<CompletionParameters>>newHashSet();
@@ -300,8 +299,7 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
     CompletionType _completionType = parameters.getCompletionType();
     Map<TokenSet, Multimap<AbstractElement, CompletionProvider<CompletionParameters>>> _get = this.myFollowElementBasedContributors.get(_completionType);
     final Multimap<AbstractElement, CompletionProvider<CompletionParameters>> element2provider = _get.get(tokenSet);
-    boolean _equals = Objects.equal(element2provider, null);
-    if (_equals) {
+    if ((element2provider == null)) {
       return;
     }
     final Set<AbstractElement> followElements = this.computeFollowElements(parameters);
@@ -371,8 +369,7 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
       return;
     }
     final ContentAssistContextFactory delegate = this.getParserBasedDelegate();
-    boolean _equals = Objects.equal(delegate, null);
-    if (_equals) {
+    if ((delegate == null)) {
       return;
     }
     String _text = this.getText(parameters);
@@ -398,8 +395,7 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
   protected ContentAssistContextFactory getParserBasedDelegate() {
     ContentAssistContextFactory _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(this.delegates, null);
-      if (_equals) {
+      if ((this.delegates == null)) {
         return null;
       }
       ContentAssistContextFactory _get = this.delegates.get();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/DebugProcessExtensions.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/DebugProcessExtensions.java
@@ -74,7 +74,7 @@ public class DebugProcessExtensions {
       URI _trimSegments = uri.trimSegments(1);
       URI _appendSegment = _trimSegments.appendSegment(lastSegmentOfTrace);
       final VirtualFile virtualFile = VirtualFileURIUtil.getVirtualFile(_appendSegment);
-      if ((Objects.equal(virtualFile, null) || (!virtualFile.exists()))) {
+      if (((virtualFile == null) || (!virtualFile.exists()))) {
         return null;
       }
       InputStream _inputStream = virtualFile.getInputStream();
@@ -117,7 +117,7 @@ public class DebugProcessExtensions {
           URI _trimSegments = uri.trimSegments(1);
           URI _appendSegment = _trimSegments.appendSegment(lastSegmentOfTrace);
           final VirtualFile virtualFile = VirtualFileURIUtil.getVirtualFile(_appendSegment);
-          if (((!Objects.equal(virtualFile, null)) && virtualFile.exists())) {
+          if (((virtualFile != null) && virtualFile.exists())) {
             InputStream _inputStream = virtualFile.getInputStream();
             final AbstractTraceRegion trace = this.traceRegionSerializer.readTraceRegionFrom(_inputStream);
             result.put(uri, trace);
@@ -136,8 +136,7 @@ public class DebugProcessExtensions {
   
   public URI findOriginalDeclaration(final DebugProcess process, final Location location) {
     final PsiFile psiFile = this.getPsiFile(process, location);
-    boolean _equals = Objects.equal(psiFile, null);
-    if (_equals) {
+    if ((psiFile == null)) {
       return null;
     } else {
       Project _project = process.getProject();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/SkippingUnwantedSteppingFilter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/SkippingUnwantedSteppingFilter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.debug;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.debugger.PositionManager;
 import com.intellij.debugger.SourcePosition;
@@ -49,7 +48,7 @@ public class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
   @Override
   public boolean isApplicable(final SuspendContext context) {
     try {
-      if ((Objects.equal(context, null) || (!this.isXtextSourced(context)))) {
+      if (((context == null) || (!this.isXtextSourced(context)))) {
         return false;
       }
       final DebugProcess debugProcess = context.getDebugProcess();
@@ -61,7 +60,7 @@ public class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
         return true;
       }
       SourcePosition _sourcePosition = positionManager.getSourcePosition(location);
-      final boolean result = Objects.equal(_sourcePosition, null);
+      final boolean result = (_sourcePosition == null);
       if (result) {
         return true;
       }
@@ -77,7 +76,7 @@ public class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
       final Location location = _frameProxy.location();
       DebugProcess _debugProcess = context.getDebugProcess();
       URI _findOriginalDeclaration = this._debugProcessExtensions.findOriginalDeclaration(_debugProcess, location);
-      return (!Objects.equal(_findOriginalDeclaration, null));
+      return (_findOriginalDeclaration != null);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -87,10 +86,9 @@ public class SkippingUnwantedSteppingFilter implements ExtraSteppingFilter {
     try {
       StackFrameProxy _frameProxy = context.getFrameProxy();
       final Location location = _frameProxy.location();
-      boolean _notEquals = (!Objects.equal(location, null));
-      if (_notEquals) {
+      if ((location != null)) {
         final Method method = location.method();
-        if (((((!Objects.equal(method, null)) && method.isConstructor()) && method.argumentTypes().isEmpty()) && (method.declaringType().name().indexOf("$") > 0))) {
+        if (((((method != null) && method.isConstructor()) && method.argumentTypes().isEmpty()) && (method.declaringType().name().indexOf("$") > 0))) {
           return true;
         }
       }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.java
@@ -163,8 +163,7 @@ public class TraceBasedPositionManagerFactory extends PositionManagerFactory {
             return Boolean.valueOf((_lineNumber == line));
           };
           final AbstractTraceRegion region = IteratorExtensions.<AbstractTraceRegion>findFirst(_treeIterator, _function);
-          boolean _notEquals_1 = (!Objects.equal(region, null));
-          if (_notEquals_1) {
+          if ((region != null)) {
             URI _key = uri2trace.getKey();
             final PsiFile psiFile = this._debugProcessExtensions.getPsiFile(this.process, _key);
             PositionManagerImpl _javaPositionManger = this._debugProcessExtensions.getJavaPositionManger(this.process);
@@ -184,14 +183,12 @@ public class TraceBasedPositionManagerFactory extends PositionManagerFactory {
       int _lineNumber = location.lineNumber();
       final int line = (_lineNumber - 1);
       final PsiFile psiFile = this._debugProcessExtensions.getPsiFile(this.process, location);
-      boolean _equals = Objects.equal(psiFile, null);
-      if (_equals) {
+      if ((psiFile == null)) {
         throw NoDataException.INSTANCE;
       }
       SourcePosition _createFromLine = SourcePosition.createFromLine(psiFile, line);
       final AbstractTraceRegion trace = this._debugProcessExtensions.getTraceForJava(_createFromLine);
-      boolean _equals_1 = Objects.equal(trace, null);
-      if (_equals_1) {
+      if ((trace == null)) {
         throw NoDataException.INSTANCE;
       }
       final URI sourceURI = this._debugProcessExtensions.findOriginalDeclaration(this.process, location);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/documentation/IdeaDocumentationProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/documentation/IdeaDocumentationProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.documentation;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.codeInsight.documentation.DocumentationManager;
 import com.intellij.lang.documentation.AbstractDocumentationProvider;
@@ -72,11 +71,9 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
   @Override
   public String getQuickNavigateInfo(final PsiElement element, final PsiElement originalElement) {
     final IdeaDocumentationProvider.GeneratedCodeDelegate gen = this.findDocumentationInGeneratedCode(element, originalElement);
-    boolean _notEquals = (!Objects.equal(gen, null));
-    if (_notEquals) {
+    if ((gen != null)) {
       final String result = gen.delegate.getQuickNavigateInfo(gen.generatedElement, gen.generatedOriginalElement);
-      boolean _notEquals_1 = (!Objects.equal(result, null));
-      if (_notEquals_1) {
+      if ((result != null)) {
         return result;
       }
     }
@@ -88,8 +85,7 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
         _quickNavigateInfo=_calleeDocumentationProvider.getQuickNavigateInfo(((PsiEObject)element));
       }
       final String result_1 = _quickNavigateInfo;
-      boolean _notEquals_2 = (!Objects.equal(result_1, null));
-      if (_notEquals_2) {
+      if ((result_1 != null)) {
         return result_1;
       }
       URI _uRI = EcoreUtil.getURI(eobj);
@@ -101,11 +97,9 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
   @Override
   public String generateDoc(final PsiElement element, final PsiElement originalElement) {
     final IdeaDocumentationProvider.GeneratedCodeDelegate gen = this.findDocumentationInGeneratedCode(element, originalElement);
-    boolean _notEquals = (!Objects.equal(gen, null));
-    if (_notEquals) {
+    if ((gen != null)) {
       final String result = gen.delegate.generateDoc(gen.generatedElement, gen.generatedOriginalElement);
-      boolean _notEquals_1 = (!Objects.equal(result, null));
-      if (_notEquals_1) {
+      if ((result != null)) {
         return result;
       }
     }
@@ -117,8 +111,7 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
         _generateDoc=_calleeDocumentationProvider.generateDoc(((PsiEObject)element));
       }
       final String result_1 = _generateDoc;
-      boolean _notEquals_2 = (!Objects.equal(result_1, null));
-      if (_notEquals_2) {
+      if ((result_1 != null)) {
         return result_1;
       }
       URI _uRI = EcoreUtil.getURI(eobj);
@@ -128,14 +121,13 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
   }
   
   protected IdeaDeclarationDocumentationProvider getCalleeDocumentationProvider(final EObject object) {
-    if ((Objects.equal(object, null) || object.eIsProxy())) {
+    if (((object == null) || object.eIsProxy())) {
       return null;
     }
     Resource _eResource = object.eResource();
     final URI uri = _eResource.getURI();
     final IResourceServiceProvider resourceServiceProvider = this.resourceServiceProviderRegistry.getResourceServiceProvider(uri);
-    boolean _equals = Objects.equal(resourceServiceProvider, null);
-    if (_equals) {
+    if ((resourceServiceProvider == null)) {
       return null;
     }
     IdeaDeclarationDocumentationProvider _get = null;
@@ -147,8 +139,7 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
   
   protected IdeaDocumentationProvider.GeneratedCodeDelegate findDocumentationInGeneratedCode(final PsiElement element, final PsiElement originalElement) {
     final PsiElement generatedElement = this.getGeneratedElement(element);
-    boolean _equals = Objects.equal(generatedElement, null);
-    if (_equals) {
+    if ((generatedElement == null)) {
       return null;
     }
     PsiElement _elvis = null;
@@ -160,8 +151,7 @@ public class IdeaDocumentationProvider extends AbstractDocumentationProvider {
     }
     final PsiElement generatedOriginalElement = _elvis;
     final DocumentationProvider delegate = DocumentationManager.getProviderFromElement(generatedElement, generatedOriginalElement);
-    boolean _equals_1 = Objects.equal(delegate, null);
-    if (_equals_1) {
+    if ((delegate == null)) {
       return null;
     }
     return new IdeaDocumentationProvider.GeneratedCodeDelegate(generatedElement, generatedOriginalElement, delegate);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AbstractIndentableAutoEditBlock.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AbstractIndentableAutoEditBlock.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.editorActions;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.formatting.IIndentationInformation;
@@ -49,8 +48,7 @@ public abstract class AbstractIndentableAutoEditBlock extends AbstractAutoEditBl
   private IIndentationInformation indentationInformation;
   
   protected String getIndentationTerminal() {
-    boolean _equals = Objects.equal(this.indentationTerminal, null);
-    if (_equals) {
+    if ((this.indentationTerminal == null)) {
       return this.indentationInformation.getIndentString();
     }
     return this.indentationTerminal;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AutoEditMultiLineBlock.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AutoEditMultiLineBlock.java
@@ -55,27 +55,24 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
   
   protected AutoEditBlockRegion findRegion(final int offset, @Extension final AutoEditContext context) {
     final TextRegion openingTerminal = this.findOpeningTerminal(offset, context);
-    boolean _equals = Objects.equal(openingTerminal, null);
-    if (_equals) {
+    if ((openingTerminal == null)) {
       return null;
     }
     TextRegion closingTerminal = this.findClosingTerminal(offset, context);
     if (((!Objects.equal(closingTerminal, Integer.valueOf((-1)))) && this.isNested())) {
       TextRegion previousOpeningTerminal = openingTerminal;
       TextRegion previousClosingTerminal = closingTerminal;
-      while ((((!Objects.equal(closingTerminal, null)) && (!Objects.equal(previousOpeningTerminal, null))) && (!Objects.equal(previousClosingTerminal, null)))) {
+      while ((((closingTerminal != null) && (previousOpeningTerminal != null)) && (previousClosingTerminal != null))) {
         {
           int _offset = previousOpeningTerminal.getOffset();
           TextRegion _findOpeningTerminal = this.findOpeningTerminal(_offset, context);
           previousOpeningTerminal = _findOpeningTerminal;
-          boolean _notEquals = (!Objects.equal(previousOpeningTerminal, null));
-          if (_notEquals) {
+          if ((previousOpeningTerminal != null)) {
             int _offset_1 = previousClosingTerminal.getOffset();
             int _plus = (_offset_1 + 1);
             TextRegion _findClosingTerminal = this.findClosingTerminal(_plus, context);
             previousClosingTerminal = _findClosingTerminal;
-            boolean _equals_1 = Objects.equal(previousClosingTerminal, null);
-            if (_equals_1) {
+            if ((previousClosingTerminal == null)) {
               closingTerminal = null;
             }
           }
@@ -95,13 +92,12 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
       {
         String _openingTerminal = this.getOpeningTerminal();
         final TextRegion openingTerminal = this.searchBackward(text, _openingTerminal, leftOffset, context);
-        boolean _equals = Objects.equal(openingTerminal, null);
-        if (_equals) {
+        if ((openingTerminal == null)) {
           return null;
         }
         String _closingTerminal = this.getClosingTerminal();
         final TextRegion closingTerminal = this.searchBackward(text, _closingTerminal, rightOffset, context);
-        if ((Objects.equal(closingTerminal, null) || (closingTerminal.getOffset() < openingTerminal.getOffset()))) {
+        if (((closingTerminal == null) || (closingTerminal.getOffset() < openingTerminal.getOffset()))) {
           return openingTerminal;
         }
         int _offset = openingTerminal.getOffset();
@@ -122,13 +118,12 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
       {
         String _closingTerminal = this.getClosingTerminal();
         final TextRegion closingTerminal = this.searchForward(text, _closingTerminal, rightOffset, context);
-        boolean _equals = Objects.equal(closingTerminal, null);
-        if (_equals) {
+        if ((closingTerminal == null)) {
           return null;
         }
         String _openingTerminal = this.getOpeningTerminal();
         final TextRegion openingTerminal = this.searchForward(text, _openingTerminal, leftOffset, context);
-        if ((Objects.equal(openingTerminal, null) || (openingTerminal.getOffset() > closingTerminal.getOffset()))) {
+        if (((openingTerminal == null) || (openingTerminal.getOffset() > closingTerminal.getOffset()))) {
           return closingTerminal;
         }
         int _offset = closingTerminal.getOffset();
@@ -222,8 +217,7 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
     boolean _isSameLine = context.isSameLine(_offset, caretOffset);
     if (_isSameLine) {
       final TextRegion closingTerminal = this.getClosingTerminal(region, context);
-      boolean _equals = Objects.equal(closingTerminal, null);
-      if (_equals) {
+      if ((closingTerminal == null)) {
         this.close(previousLineIndentation, context);
       } else {
         if ((context.isSameLine(closingTerminal.getOffset(), caretOffset) && (closingTerminal.getOffset() >= caretOffset))) {
@@ -240,8 +234,8 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
       return this.getIndentationTerminal();
     }
     TextRegion _closingTerminal = region.getClosingTerminal();
-    boolean _equals_1 = Objects.equal(_closingTerminal, null);
-    if (_equals_1) {
+    boolean _tripleEquals = (_closingTerminal == null);
+    if (_tripleEquals) {
       this.close(previousLineIndentation, context);
       return "";
     }
@@ -251,8 +245,7 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
   
   protected TextRegion getClosingTerminal(final AutoEditBlockRegion region, @Extension final AutoEditContext context) {
     final TextRegion closingTerminal = region.getClosingTerminal();
-    boolean _equals = Objects.equal(closingTerminal, null);
-    if (_equals) {
+    if ((closingTerminal == null)) {
       return null;
     }
     if (((closingTerminal.getLength() < this.getClosingTerminal().length()) && context.isSameLine(closingTerminal.getOffset(), context.getCaretOffset()))) {
@@ -290,16 +283,14 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
   public boolean close(final char c, @Extension final AutoEditContext context) {
     int _caretOffset = context.getCaretOffset();
     final AutoEditBlockRegion region = this.findRegion(_caretOffset, context);
-    boolean _equals = Objects.equal(region, null);
-    if (_equals) {
+    if ((region == null)) {
       return false;
     }
     final AutoEditBlockRegion openedRegion = this.findOpenedRegion(region, context);
-    boolean _notEquals = (!Objects.equal(openedRegion, null));
-    if (_notEquals) {
+    if ((openedRegion != null)) {
       context.type(c);
     } else {
-      if (((!Objects.equal(region.getClosingTerminal(), null)) && region.getClosingTerminal().contains(context.getCaretOffset()))) {
+      if (((region.getClosingTerminal() != null) && region.getClosingTerminal().contains(context.getCaretOffset()))) {
         EditorEx _editor = context.getEditor();
         EditorModificationUtil.moveCaretRelatively(_editor, 1);
       } else {
@@ -310,13 +301,12 @@ public class AutoEditMultiLineBlock extends AbstractIndentableAutoEditBlock {
   }
   
   protected AutoEditBlockRegion findOpenedRegion(final AutoEditBlockRegion region, @Extension final AutoEditContext context) {
-    boolean _equals = Objects.equal(region, null);
-    if (_equals) {
+    if ((region == null)) {
       return null;
     }
     TextRegion _closingTerminal = region.getClosingTerminal();
-    boolean _equals_1 = Objects.equal(_closingTerminal, null);
-    if (_equals_1) {
+    boolean _tripleEquals = (_closingTerminal == null);
+    if (_tripleEquals) {
       return region;
     }
     TextRegion _openingTerminal = region.getOpeningTerminal();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AutoEditString.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/AutoEditString.java
@@ -51,13 +51,12 @@ public class AutoEditString extends AbstractAutoEditBlock {
   public boolean close(final char c, @Extension final AutoEditContext context) {
     int _caretOffset = context.getCaretOffset();
     final AutoEditStringRegion stringRegion = this.findRegion(_caretOffset, context);
-    boolean _equals = Objects.equal(stringRegion, null);
-    if (_equals) {
+    if ((stringRegion == null)) {
       return false;
     }
     TextRegion _closingTerminal = stringRegion.getClosingTerminal();
-    boolean _equals_1 = Objects.equal(_closingTerminal, null);
-    if (_equals_1) {
+    boolean _tripleEquals = (_closingTerminal == null);
+    if (_tripleEquals) {
       context.type(c);
     } else {
       TextRegion _closingTerminal_1 = stringRegion.getClosingTerminal();
@@ -75,14 +74,12 @@ public class AutoEditString extends AbstractAutoEditBlock {
   
   protected AutoEditStringRegion findRegion(final int offset, @Extension final AutoEditContext context) {
     final TextRegion openingTerminal = this.findOpeningTerminal(offset, context);
-    boolean _equals = Objects.equal(openingTerminal, null);
-    if (_equals) {
+    if ((openingTerminal == null)) {
       return null;
     }
     int _offset = openingTerminal.getOffset();
     final TextRegion closingTerminal = this.findClosingTerminal(offset, _offset, context);
-    boolean _notEquals = (!Objects.equal(closingTerminal, null));
-    if (_notEquals) {
+    if ((closingTerminal != null)) {
       int _offset_1 = openingTerminal.getOffset();
       boolean _greaterEqualsThan = (_offset_1 >= offset);
       if (_greaterEqualsThan) {
@@ -111,8 +108,7 @@ public class AutoEditString extends AbstractAutoEditBlock {
       while ((!iterator.atEnd())) {
         {
           final TextRegion openingTerminal = this.getOpeningTerminal(iterator, context);
-          boolean _notEquals = (!Objects.equal(openingTerminal, null));
-          if (_notEquals) {
+          if ((openingTerminal != null)) {
             return openingTerminal;
           }
           iterator.retreat();
@@ -135,8 +131,7 @@ public class AutoEditString extends AbstractAutoEditBlock {
       while ((!iterator.atEnd())) {
         {
           final TextRegion closingTerminal = this.getClosingTerminal(iterator, openingTokenOffset, context);
-          boolean _notEquals = (!Objects.equal(closingTerminal, null));
-          if (_notEquals) {
+          if ((closingTerminal != null)) {
             return closingTerminal;
           }
           iterator.advance();
@@ -148,8 +143,7 @@ public class AutoEditString extends AbstractAutoEditBlock {
   }
   
   protected TextRegion getOpeningTerminal(final HighlighterIterator iterator, @Extension final AutoEditContext context) {
-    boolean _equals = Objects.equal(iterator, null);
-    if (_equals) {
+    if ((iterator == null)) {
       return null;
     }
     int _end = iterator.getEnd();
@@ -179,8 +173,7 @@ public class AutoEditString extends AbstractAutoEditBlock {
   }
   
   protected TextRegion getClosingTerminal(final HighlighterIterator iterator, final int openingTokenOffset, @Extension final AutoEditContext context) {
-    boolean _equals = Objects.equal(iterator, null);
-    if (_equals) {
+    if ((iterator == null)) {
       return null;
     }
     int _end = iterator.getEnd();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/DefaultAutoEditHandler.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/DefaultAutoEditHandler.java
@@ -61,8 +61,7 @@ public class DefaultAutoEditHandler extends IdeaAutoEditHandler {
   public IdeaAutoEditHandler.Result beforeEnterTyped(final PsiFile file, final EditorEx editor, final Ref<Integer> caretOffset, final Ref<Integer> caretAdvance, final DataContext dataContext, final EditorActionHandler originalHandler) {
     final AutoEditContext context = new AutoEditContext(editor, this.tokenSetProvider);
     final AutoEditBlockRegion region = this.findBlockRegion(context);
-    boolean _equals = Objects.equal(region, null);
-    if (_equals) {
+    if ((region == null)) {
       return IdeaAutoEditHandler.Result.CONTINUE;
     }
     return this.handleIndentation(region, context);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditBackspaceHandler.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditBackspaceHandler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.editorActions;
 
-import com.google.common.base.Objects;
 import com.intellij.codeInsight.editorActions.BackspaceHandlerDelegate;
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Editor;
@@ -25,8 +24,7 @@ public class XtextAutoEditBackspaceHandler extends BackspaceHandlerDelegate {
   public void beforeCharDeleted(final char c, final PsiFile file, final Editor editor) {
     Language _language = file.getLanguage();
     final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
-    boolean _notEquals = (!Objects.equal(autoEditHandler, null));
-    if (_notEquals) {
+    if ((autoEditHandler != null)) {
       autoEditHandler.beforeCharDeleted(c, file, ((EditorEx) editor));
     }
   }
@@ -38,8 +36,7 @@ public class XtextAutoEditBackspaceHandler extends BackspaceHandlerDelegate {
       Language _language = file.getLanguage();
       final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
       boolean _xifexpression = false;
-      boolean _notEquals = (!Objects.equal(autoEditHandler, null));
-      if (_notEquals) {
+      if ((autoEditHandler != null)) {
         _xifexpression = autoEditHandler.charDeleted(c, file, ((EditorEx) editor));
       } else {
         _xifexpression = false;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditEnterHandler.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditEnterHandler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.editorActions;
 
-import com.google.common.base.Objects;
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate;
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter;
 import com.intellij.lang.Language;
@@ -29,8 +28,7 @@ public class XtextAutoEditEnterHandler extends EnterHandlerDelegateAdapter {
   public EnterHandlerDelegate.Result preprocessEnter(final PsiFile file, final Editor editor, final Ref<Integer> caretOffset, final Ref<Integer> caretAdvance, final DataContext dataContext, final EditorActionHandler originalHandler) {
     Language _language = file.getLanguage();
     final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
-    boolean _equals = Objects.equal(autoEditHandler, null);
-    if (_equals) {
+    if ((autoEditHandler == null)) {
       return super.preprocessEnter(file, editor, caretOffset, caretAdvance, dataContext, originalHandler);
     }
     IdeaAutoEditHandler.Result _beforeEnterTyped = autoEditHandler.beforeEnterTyped(file, 
@@ -42,8 +40,7 @@ public class XtextAutoEditEnterHandler extends EnterHandlerDelegateAdapter {
   public EnterHandlerDelegate.Result postProcessEnter(final PsiFile file, final Editor editor, final DataContext dataContext) {
     Language _language = file.getLanguage();
     final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
-    boolean _equals = Objects.equal(autoEditHandler, null);
-    if (_equals) {
+    if ((autoEditHandler == null)) {
       return super.postProcessEnter(file, editor, dataContext);
     }
     IdeaAutoEditHandler.Result _enterTyped = autoEditHandler.enterTyped(file, ((EditorEx) editor), dataContext);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditTypedHandler.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/editorActions/XtextAutoEditTypedHandler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.editorActions;
 
-import com.google.common.base.Objects;
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Editor;
@@ -27,8 +26,7 @@ public class XtextAutoEditTypedHandler extends TypedHandlerDelegate {
   public TypedHandlerDelegate.Result beforeCharTyped(final char c, final Project project, final Editor editor, final PsiFile file, final FileType fileType) {
     Language _language = file.getLanguage();
     final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
-    boolean _equals = Objects.equal(autoEditHandler, null);
-    if (_equals) {
+    if ((autoEditHandler == null)) {
       return super.beforeCharTyped(c, project, editor, file, fileType);
     }
     IdeaAutoEditHandler.Result _beforeCharTyped = autoEditHandler.beforeCharTyped(c, project, ((EditorEx) editor), file, fileType);
@@ -39,8 +37,7 @@ public class XtextAutoEditTypedHandler extends TypedHandlerDelegate {
   public TypedHandlerDelegate.Result charTyped(final char c, final Project project, final Editor editor, final PsiFile file) {
     Language _language = file.getLanguage();
     final IdeaAutoEditHandler autoEditHandler = IdeaAutoEditHandlerExtension.INSTANCE.forLanguage(_language);
-    boolean _equals = Objects.equal(autoEditHandler, null);
-    if (_equals) {
+    if ((autoEditHandler == null)) {
       return super.charTyped(c, project, editor, file);
     }
     IdeaAutoEditHandler.Result _charTyped = autoEditHandler.charTyped(c, project, ((EditorEx) editor), file);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.execution;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.execution.Location;
 import com.intellij.execution.PsiLocation;
@@ -100,8 +99,7 @@ public class ConfigurationProducerExtensions {
       return CollectionLiterals.<PsiFile>emptySet();
     }
     final VirtualFileInProject fileInProject = VirtualFileInProject.forPsiElement(xtextFile);
-    boolean _equals = Objects.equal(fileInProject, null);
-    if (_equals) {
+    if ((fileInProject == null)) {
       return CollectionLiterals.<PsiFile>emptySet();
     }
     final IIdeaTrace trace = this.traceProvider.getTraceToTarget(fileInProject);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/TraceBasedExceptionFilter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/TraceBasedExceptionFilter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.execution;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.execution.filters.ExceptionFilter;
 import com.intellij.execution.filters.FileHyperlinkInfo;
@@ -50,21 +49,19 @@ public class TraceBasedExceptionFilter extends ExceptionFilter {
   @Override
   public Filter.Result applyFilter(final String line, final int textEndOffset) {
     final Filter.Result result = super.applyFilter(line, textEndOffset);
-    boolean _equals = Objects.equal(result, null);
-    if (_equals) {
+    if ((result == null)) {
       return null;
     }
     List<Filter.ResultItem> _resultItems = result.getResultItems();
     final Function1<Filter.ResultItem, Boolean> _function = (Filter.ResultItem it) -> {
       HyperlinkInfo _hyperlinkInfo = it.getHyperlinkInfo();
-      return Boolean.valueOf((!Objects.equal(_hyperlinkInfo, null)));
+      return Boolean.valueOf((_hyperlinkInfo != null));
     };
     final Filter.ResultItem resultItem = IterableExtensions.<Filter.ResultItem>findFirst(_resultItems, _function);
     final HyperlinkInfo hyperlinkInfo = resultItem.getHyperlinkInfo();
     if ((hyperlinkInfo instanceof FileHyperlinkInfo)) {
       final OpenFileDescriptor descriptor = ((FileHyperlinkInfo)hyperlinkInfo).getDescriptor();
-      boolean _notEquals = (!Objects.equal(descriptor, null));
-      if (_notEquals) {
+      if ((descriptor != null)) {
         VirtualFile _file = descriptor.getFile();
         Project _project = descriptor.getProject();
         final VirtualFileInProject fileInProject = new VirtualFileInProject(_file, _project);
@@ -72,7 +69,7 @@ public class TraceBasedExceptionFilter extends ExceptionFilter {
         if (_isGenerated) {
           final IIdeaTrace trace = this.traceProvider.getTraceToSource(fileInProject);
           final RangeMarker rangeMarker = descriptor.getRangeMarker();
-          if (((!Objects.equal(trace, null)) && (!Objects.equal(rangeMarker, null)))) {
+          if (((trace != null) && (rangeMarker != null))) {
             Application _application = ApplicationManager.getApplication();
             final Computable<Integer> _function_1 = () -> {
               int _xblockexpression = (int) 0;
@@ -89,8 +86,7 @@ public class TraceBasedExceptionFilter extends ExceptionFilter {
             final Integer nonSpaceCharOffset = _application.<Integer>runReadAction(_function_1);
             TextRegion _textRegion = new TextRegion((nonSpaceCharOffset).intValue(), 0);
             final ILocationInVirtualFile location = trace.getBestAssociatedLocation(_textRegion);
-            boolean _notEquals_1 = (!Objects.equal(location, null));
-            if (_notEquals_1) {
+            if ((location != null)) {
               VirtualFileInProject _platformResource = location.getPlatformResource();
               Project _project_1 = _platformResource.getProject();
               VirtualFileInProject _platformResource_1 = location.getPlatformResource();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/AbstractExecutableExtensionPoint.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/AbstractExecutableExtensionPoint.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.extensions;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.extensions.AbstractExtensionPointBean;
 import com.intellij.openapi.extensions.ExtensionFactory;
 import com.intellij.openapi.extensions.PluginDescriptor;
@@ -44,13 +43,11 @@ public abstract class AbstractExecutableExtensionPoint extends AbstractExtension
     try {
       Object _xblockexpression = null;
       {
-        boolean _equals = Objects.equal(this.implementationClass, null);
-        if (_equals) {
+        if ((this.implementationClass == null)) {
           throw this.asRuntimeException("Class is not specified");
         }
         Object _xifexpression = null;
-        boolean _equals_1 = Objects.equal(this.factoryClass, null);
-        if (_equals_1) {
+        if ((this.factoryClass == null)) {
           Class<Object> _findClass = this.<Object>findClass(this.implementationClass);
           _xifexpression = _findClass.newInstance();
         } else {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.extensions;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.Extensions;
@@ -50,24 +49,24 @@ public class EcoreGlobalRegistries {
     ResourceServiceProviderEP[] _extensions_2 = Extensions.<ResourceServiceProviderEP>getExtensions(ResourceServiceProviderEP.EP_NAME);
     final Consumer<ResourceServiceProviderEP> _function_2 = (ResourceServiceProviderEP it) -> {
       String _uriExtension = it.getUriExtension();
-      boolean _notEquals = (!Objects.equal(_uriExtension, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_uriExtension != null);
+      if (_tripleNotEquals) {
         Map<String, Object> _extensionToFactoryMap = registry.getExtensionToFactoryMap();
         String _uriExtension_1 = it.getUriExtension();
         ResourceServiceProviderDescriptor _createDescriptor = it.createDescriptor();
         _extensionToFactoryMap.put(_uriExtension_1, _createDescriptor);
       }
       String _protocolName = it.getProtocolName();
-      boolean _notEquals_1 = (!Objects.equal(_protocolName, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_protocolName != null);
+      if (_tripleNotEquals_1) {
         Map<String, Object> _protocolToFactoryMap = registry.getProtocolToFactoryMap();
         String _protocolName_1 = it.getProtocolName();
         ResourceServiceProviderDescriptor _createDescriptor_1 = it.createDescriptor();
         _protocolToFactoryMap.put(_protocolName_1, _createDescriptor_1);
       }
       String _contentTypeIdentifier = it.getContentTypeIdentifier();
-      boolean _notEquals_2 = (!Objects.equal(_contentTypeIdentifier, null));
-      if (_notEquals_2) {
+      boolean _tripleNotEquals_2 = (_contentTypeIdentifier != null);
+      if (_tripleNotEquals_2) {
         Map<String, Object> _contentTypeToFactoryMap = registry.getContentTypeToFactoryMap();
         String _contentTypeIdentifier_1 = it.getContentTypeIdentifier();
         ResourceServiceProviderDescriptor _createDescriptor_2 = it.createDescriptor();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/ResourceFactoryDescriptor.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/ResourceFactoryDescriptor.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.extensions;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.idea.extensions.AbstractExecutableExtensionPoint;
@@ -21,8 +20,7 @@ public class ResourceFactoryDescriptor implements Resource.Factory.Descriptor {
   
   @Override
   public Resource.Factory createFactory() {
-    boolean _equals = Objects.equal(this.factory, null);
-    if (_equals) {
+    if ((this.factory == null)) {
       Object _createInstance = this.extensionPoint.createInstance();
       this.factory = ((Resource.Factory) _createInstance);
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/ResourceServiceProviderDescriptor.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/ResourceServiceProviderDescriptor.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.extensions;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.idea.extensions.AbstractExecutableExtensionPoint;
 import org.eclipse.xtext.internal.AbstractResourceServiceProviderDescriptor;
@@ -26,8 +25,7 @@ public class ResourceServiceProviderDescriptor extends AbstractResourceServicePr
   
   @Override
   protected Object getExtension() {
-    boolean _equals = Objects.equal(this.myExtension, null);
-    if (_equals) {
+    if ((this.myExtension == null)) {
       Object _createInstance = this.extensionPoint.createInstance();
       this.myExtension = _createInstance;
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/RootModelExtensions.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/RootModelExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.extensions;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ContentEntry;
@@ -38,7 +37,7 @@ public class RootModelExtensions {
     Iterable<SourceFolder> _sourceFolders = RootModelExtensions.getSourceFolders(module);
     final Function1<SourceFolder, Boolean> _function = (SourceFolder it) -> {
       VirtualFile _file = it.getFile();
-      return Boolean.valueOf((!Objects.equal(_file, null)));
+      return Boolean.valueOf((_file != null));
     };
     return IterableExtensions.<SourceFolder>filter(_sourceFolders, _function);
   }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/facet/GeneratorConfigurationState.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/facet/GeneratorConfigurationState.java
@@ -13,8 +13,7 @@ public class GeneratorConfigurationState {
   
   public GeneratorConfigurationState(final OutputConfiguration defOutput) {
     this.activated = true;
-    boolean _notEquals = (!Objects.equal(defOutput, null));
-    if (_notEquals) {
+    if ((defOutput != null)) {
       String outputDir = defOutput.getOutputDirectory();
       boolean _equals = Objects.equal("./src-gen", outputDir);
       if (_equals) {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/filesystem/IdeaProjectConfig.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/filesystem/IdeaProjectConfig.java
@@ -53,20 +53,18 @@ public class IdeaProjectConfig implements IProjectConfig {
     VirtualFileManager _instance = VirtualFileManager.getInstance();
     String _string = member.toString();
     final VirtualFile file = _instance.findFileByUrl(_string);
-    boolean _equals = Objects.equal(file, null);
-    if (_equals) {
+    if ((file == null)) {
       return null;
     }
     Project _project = this.module.getProject();
     ProjectRootManager _instance_1 = ProjectRootManager.getInstance(_project);
     ProjectFileIndex _fileIndex = _instance_1.getFileIndex();
     final VirtualFile sourceRoot = _fileIndex.getSourceRootForFile(file);
-    boolean _equals_1 = Objects.equal(sourceRoot, null);
-    if (_equals_1) {
+    if ((sourceRoot == null)) {
       return null;
     }
     final SourceFolder sourceFolder = ProjectRootsUtil.findSourceFolder(this.module, sourceRoot);
-    if ((Objects.equal(sourceFolder, null) || (!Objects.equal(sourceFolder.getContentEntry().getFile(), this.contentRoot)))) {
+    if (((sourceFolder == null) || (!Objects.equal(sourceFolder.getContentEntry().getFile(), this.contentRoot)))) {
       return null;
     }
     return new IdeaSourceFolder(sourceFolder);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/findusages/GeneratedSourceAwareUsagesHandlerFactory.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/findusages/GeneratedSourceAwareUsagesHandlerFactory.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.findusages;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.find.findUsages.FindUsagesHandler;
 import com.intellij.find.findUsages.FindUsagesHandlerFactory;
@@ -148,7 +147,7 @@ public class GeneratedSourceAwareUsagesHandlerFactory extends FindUsagesHandlerF
     for (final PsiElement generatedElement : _generatedElements) {
       {
         final PsiNamedElement parent = PsiTreeUtil.<PsiNamedElement>getParentOfType(generatedElement, PsiNamedElement.class, false);
-        if (((!Objects.equal(parent, null)) && (!result.contains(parent)))) {
+        if (((parent != null) && (!result.contains(parent)))) {
           result.add(parent);
         }
       }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/BlockExtension.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/BlockExtension.java
@@ -93,8 +93,7 @@ public class BlockExtension {
   public boolean isOpening(final ASTNode node) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(node, null);
-      if (_equals) {
+      if ((node == null)) {
         return false;
       }
       final String text = node.getText();
@@ -111,8 +110,7 @@ public class BlockExtension {
   public boolean isClosing(final ASTNode node) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(node, null);
-      if (_equals) {
+      if ((node == null)) {
         return false;
       }
       final String text = node.getText();
@@ -134,8 +132,7 @@ public class BlockExtension {
   public BracePair getBracePairForOpeningNode(final ASTNode node) {
     BracePair _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(node, null);
-      if (_equals) {
+      if ((node == null)) {
         return null;
       }
       final String openingBrace = node.getText();
@@ -157,8 +154,7 @@ public class BlockExtension {
   public BracePair getBracePairForClosingNode(final ASTNode node) {
     BracePair _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(node, null);
-      if (_equals) {
+      if ((node == null)) {
         return null;
       }
       final String openingBrace = node.getText();
@@ -182,7 +178,7 @@ public class BlockExtension {
       final int offset = (_startOffset - _startOffset_1);
       final ASTNode leafElement = node.findLeafElementAt(offset);
       final BracePair bracePair = this.getBracePairForOpeningNode(leafElement);
-      _xblockexpression = ((!Objects.equal(bracePair, null)) && bracePair.isStructural());
+      _xblockexpression = ((bracePair != null) && bracePair.isStructural());
     }
     return _xblockexpression;
   }
@@ -194,8 +190,7 @@ public class BlockExtension {
   public final static Indent STRUCTURAL_INDENT = Indent.getIndent(Indent.Type.NORMAL, false, true);
   
   public Indent getIndent(final BracePair bracePair, final boolean enforceIndentToChildren) {
-    boolean _equals = Objects.equal(bracePair, null);
-    if (_equals) {
+    if ((bracePair == null)) {
       return Indent.getNoneIndent();
     }
     boolean _isStructural = bracePair.isStructural();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultBlockFactory.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultBlockFactory.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.formatting;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
@@ -74,7 +73,7 @@ public class DefaultBlockFactory implements BlockFactory {
         return null;
       }
       final TextRange blockTextRange = this.createTextRange(node);
-      if (((Objects.equal(blockTextRange, null) || blockTextRange.isEmpty()) || (!parentBlock.getTextRange().contains(blockTextRange)))) {
+      if ((((blockTextRange == null) || blockTextRange.isEmpty()) || (!parentBlock.getTextRange().contains(blockTextRange)))) {
         return null;
       }
       SpacingBuilder _xifexpression = null;
@@ -142,8 +141,8 @@ public class DefaultBlockFactory implements BlockFactory {
         return textRange;
       }
       ASTNode _firstChildNode = node.getFirstChildNode();
-      boolean _equals_1 = Objects.equal(_firstChildNode, null);
-      if (_equals_1) {
+      boolean _tripleEquals = (_firstChildNode == null);
+      if (_tripleEquals) {
         return textRange;
       }
       LeafElement _findFirstLeaf = TreeUtil.findFirstLeaf(node);
@@ -154,7 +153,7 @@ public class DefaultBlockFactory implements BlockFactory {
         return Boolean.valueOf(((!FormatterUtil.isWhitespaceOrEmpty(it)) || (!textRange.contains(it.getTextRange()))));
       };
       final ASTNode firstNonHiddenLeafNode = this.findNode(_findFirstLeaf, _function, _function_1);
-      if ((Objects.equal(firstNonHiddenLeafNode, null) || (!textRange.contains(firstNonHiddenLeafNode.getTextRange())))) {
+      if (((firstNonHiddenLeafNode == null) || (!textRange.contains(firstNonHiddenLeafNode.getTextRange())))) {
         return null;
       }
       final int startOffset = firstNonHiddenLeafNode.getStartOffset();
@@ -175,8 +174,7 @@ public class DefaultBlockFactory implements BlockFactory {
   }
   
   protected ASTNode findNode(final ASTNode node, final Function1<? super ASTNode, ? extends ASTNode> provider, final Function1<? super ASTNode, ? extends Boolean> condition) {
-    boolean _equals = Objects.equal(node, null);
-    if (_equals) {
+    if ((node == null)) {
       return null;
     }
     Boolean _apply = condition.apply(node);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultChildAttributesProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultChildAttributesProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.formatting;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.intellij.formatting.Block;
@@ -58,8 +57,7 @@ public class DefaultChildAttributesProvider implements ChildAttributesProvider {
       return this.getAfterChildIndent(block, _size_1);
     }
     final Indent indent = this.getBeforeChildIndent(block, newChildIndex);
-    boolean _equals = Objects.equal(indent, null);
-    if (_equals) {
+    if ((indent == null)) {
       return this.getAfterChildIndent(block, newChildIndex);
     }
     return indent;
@@ -104,14 +102,12 @@ public class DefaultChildAttributesProvider implements ChildAttributesProvider {
   }
   
   protected Indent getAfterChildIndent(final Block block) {
-    boolean _equals = Objects.equal(block, null);
-    if (_equals) {
+    if ((block == null)) {
       return null;
     }
     EObject _grammarElement = this._blockExtension.getGrammarElement(block);
     final Indent grammarElementIndent = this.getIndentAfter(_grammarElement);
-    boolean _notEquals = (!Objects.equal(grammarElementIndent, null));
-    if (_notEquals) {
+    if ((grammarElementIndent != null)) {
       return grammarElementIndent;
     }
     if ((block instanceof SyntheticXtextBlock)) {
@@ -130,14 +126,12 @@ public class DefaultChildAttributesProvider implements ChildAttributesProvider {
   }
   
   protected Indent getBeforeChildIndent(final Block block) {
-    boolean _equals = Objects.equal(block, null);
-    if (_equals) {
+    if ((block == null)) {
       return null;
     }
     EObject _grammarElement = this._blockExtension.getGrammarElement(block);
     final Indent grammarElementIndent = this.getIndentBefore(_grammarElement);
-    boolean _notEquals = (!Objects.equal(grammarElementIndent, null));
-    if (_notEquals) {
+    if ((grammarElementIndent != null)) {
       return grammarElementIndent;
     }
     if ((block instanceof SyntheticXtextBlock)) {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultCommenter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultCommenter.java
@@ -73,8 +73,7 @@ public class DefaultCommenter implements CodeDocumentationAwareCommenter {
       };
       final Map.Entry<Integer, String> mlCommentEntry = IterableExtensions.<Map.Entry<Integer, String>>findFirst(_entrySet, _function);
       IElementType _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(mlCommentEntry, null));
-      if (_notEquals) {
+      if ((mlCommentEntry != null)) {
         Integer _key = mlCommentEntry.getKey();
         _xifexpression = tokenTypeProvider.getIElementType((_key).intValue());
       }
@@ -85,8 +84,7 @@ public class DefaultCommenter implements CodeDocumentationAwareCommenter {
   
   @Override
   public String getLineCommentPrefix() {
-    boolean _notEquals = (!Objects.equal(this.slCommentTokenType, null));
-    if (_notEquals) {
+    if ((this.slCommentTokenType != null)) {
       return this.lineCommentPrefix;
     }
     return null;
@@ -94,8 +92,7 @@ public class DefaultCommenter implements CodeDocumentationAwareCommenter {
   
   @Override
   public String getBlockCommentPrefix() {
-    boolean _notEquals = (!Objects.equal(this.mlCommentTokenType, null));
-    if (_notEquals) {
+    if ((this.mlCommentTokenType != null)) {
       return this.blockCommentPrefix;
     }
     return null;
@@ -103,8 +100,7 @@ public class DefaultCommenter implements CodeDocumentationAwareCommenter {
   
   @Override
   public String getBlockCommentSuffix() {
-    boolean _notEquals = (!Objects.equal(this.mlCommentTokenType, null));
-    if (_notEquals) {
+    if ((this.mlCommentTokenType != null)) {
       return this.blockCommentSuffix;
     }
     return null;
@@ -127,8 +123,7 @@ public class DefaultCommenter implements CodeDocumentationAwareCommenter {
   
   @Override
   public String getDocumentationCommentLinePrefix() {
-    boolean _notEquals = (!Objects.equal(this.mlCommentTokenType, null));
-    if (_notEquals) {
+    if ((this.mlCommentTokenType != null)) {
       return this.documentationCommentLinePrefix;
     }
     return null;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.java
@@ -83,8 +83,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
   
   @Override
   public boolean isIncomplete() {
-    boolean _notEquals = (!Objects.equal(this.incomplete, null));
-    if (_notEquals) {
+    if ((this.incomplete != null)) {
       return (this.incomplete).booleanValue();
     }
     return super.isIncomplete();
@@ -92,8 +91,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
   
   @Override
   public TextRange getTextRange() {
-    boolean _notEquals = (!Objects.equal(this.textRange, null));
-    if (_notEquals) {
+    if ((this.textRange != null)) {
       return this.textRange;
     }
     return super.getTextRange();
@@ -128,8 +126,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
             final BracePair bracePair_1 = this._blockExtension.getBracePairForClosingBrace(block);
             List<Integer> _get = openingBlockIndex.get(bracePair_1);
             final Integer index = IterableExtensions.<Integer>last(_get);
-            boolean _notEquals = (!Objects.equal(index, null));
-            if (_notEquals) {
+            if ((index != null)) {
               openingBlockIndex.remove(bracePair_1, index);
               this.group(stack, index, bracePair_1, block);
             }
@@ -162,7 +159,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
       return;
     }
     final SyntheticXtextBlock groupBlock = this.createGroup(children);
-    groupBlock.setIncomplete(Boolean.valueOf((Objects.equal(closingBlock, null) || Objects.equal(this._blockExtension.getElementType(closingBlock), TokenType.ERROR_ELEMENT))));
+    groupBlock.setIncomplete(Boolean.valueOf(((closingBlock == null) || Objects.equal(this._blockExtension.getElementType(closingBlock), TokenType.ERROR_ELEMENT))));
     final boolean enforceIndentToChildren = this.shouldEnforceIndentToChildren(children);
     Indent _indent = this._blockExtension.getIndent(bracePair, enforceIndentToChildren);
     groupBlock.setIndent(_indent);
@@ -201,7 +198,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
     }
     Block _head = IterableExtensions.<Block>head(children);
     final BracePair bracePair = this._blockExtension.getBracePairForOpeningBrace(_head);
-    if ((Objects.equal(bracePair, null) || (!bracePair.isStructural()))) {
+    if (((bracePair == null) || (!bracePair.isStructural()))) {
       return true;
     }
     Block _last = IterableExtensions.<Block>last(children);
@@ -230,7 +227,7 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
   @Override
   public boolean isLeaf() {
     ASTNode _firstChildNode = this.myNode.getFirstChildNode();
-    return Objects.equal(_firstChildNode, null);
+    return (_firstChildNode == null);
   }
   
   @Override

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/highlighting/IdeaHighlightingAttributesProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/highlighting/IdeaHighlightingAttributesProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.highlighting;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -53,8 +52,7 @@ public class IdeaHighlightingAttributesProvider {
   private Map<String, String> xtextStyle2xtextStyleRedirectMap;
   
   protected void initialize() {
-    boolean _equals = Objects.equal(this.attributesDescriptors, null);
-    if (_equals) {
+    if ((this.attributesDescriptors == null)) {
       ArrayList<AttributesDescriptor> _newArrayList = CollectionLiterals.<AttributesDescriptor>newArrayList();
       this.attributesDescriptors = _newArrayList;
       HashMap<String, HighlightInfoType> _newHashMap = CollectionLiterals.<String, HighlightInfoType>newHashMap();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/nodemodel/ASTNodeAwareNodeModelBuilder.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/nodemodel/ASTNodeAwareNodeModelBuilder.java
@@ -68,8 +68,7 @@ public class ASTNodeAwareNodeModelBuilder extends NodeModelBuilder implements IA
   
   protected void replaceAssociations(final INode oldNode, final INode newNode) {
     final List<ASTNode> mapping = this.reverseNodesMapping.remove(oldNode);
-    boolean _notEquals = (!Objects.equal(mapping, null));
-    if (_notEquals) {
+    if ((mapping != null)) {
       for (final ASTNode astNode : mapping) {
         this.associate(astNode, newNode);
       }
@@ -120,8 +119,7 @@ public class ASTNodeAwareNodeModelBuilder extends NodeModelBuilder implements IA
         {
           final IElementType tokenType = it.<IElementType>getUserData(IASTNodeAwareNodeModelBuilder.TOKEN_TYPE_KEY);
           AbstractRule _xifexpression_1 = null;
-          boolean _notEquals = (!Objects.equal(tokenType, null));
-          if (_notEquals) {
+          if ((tokenType != null)) {
             AbstractRule _xblockexpression_2 = null;
             {
               final String tokenName = tokenType.toString();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AbstractPsiAntlrParser.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AbstractPsiAntlrParser.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.parser;
 
-import com.google.common.base.Objects;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.tree.IElementType;
@@ -185,8 +184,7 @@ public abstract class AbstractPsiAntlrParser extends Parser {
   
   protected void doneLeaf(final Token matchedToken) {
     final IElementType tokenType = this.psiInput.remapToken(null);
-    boolean _equals = Objects.equal(matchedToken, null);
-    if (_equals) {
+    if ((matchedToken == null)) {
       PsiBuilder.Marker _mark = this.psiBuilder.mark();
       GrammarAwareErrorElementType _grammarAwareErrorElementType = new GrammarAwareErrorElementType(tokenType);
       _mark.done(_grammarAwareErrorElementType);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AbstractXtextPsiParser.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AbstractXtextPsiParser.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.parser;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.intellij.lang.ASTNode;
@@ -73,8 +72,7 @@ public abstract class AbstractXtextPsiParser implements PsiParser {
         final AbstractPsiAntlrParser parser = ObjectExtensions.<AbstractPsiAntlrParser>operator_doubleArrow(_createParser, _function);
         PsiBuilder.Marker rootMarker = builder.mark();
         final String entryRuleName = this.getEntryRuleName(root);
-        boolean _notEquals = (!Objects.equal(entryRuleName, null));
-        if (_notEquals) {
+        if ((entryRuleName != null)) {
           parser.parse(entryRuleName);
         } else {
           parser.parse();
@@ -120,8 +118,7 @@ public abstract class AbstractXtextPsiParser implements PsiParser {
       PsiXtextTokenStream _psiXtextTokenStream = new PsiXtextTokenStream(builder, tokenSource, this.tokenDefProvider);
       final Procedure1<PsiXtextTokenStream> _function = (PsiXtextTokenStream it) -> {
         final Integer lookAhead = builder.<Integer>getUserData(IASTNodeAwareNodeModelBuilder.LOOK_AHEAD_KEY);
-        boolean _notEquals = (!Objects.equal(lookAhead, null));
-        if (_notEquals) {
+        if ((lookAhead != null)) {
           it.initCurrentLookAhead((lookAhead).intValue());
         }
         Set<String> _initialHiddenTokens = this.getInitialHiddenTokens();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AntlrDelegatingIdeaLexer.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/AntlrDelegatingIdeaLexer.java
@@ -55,8 +55,7 @@ public class AntlrDelegatingIdeaLexer extends LexerBase {
   @Override
   public IElementType getTokenType() {
     this.locateToken();
-    boolean _equals = Objects.equal(this.token, null);
-    if (_equals) {
+    if ((this.token == null)) {
       return null;
     }
     final int type = this.token.getType();
@@ -104,8 +103,7 @@ public class AntlrDelegatingIdeaLexer extends LexerBase {
   }
   
   public void locateToken() {
-    boolean _equals = Objects.equal(this.token, null);
-    if (_equals) {
+    if ((this.token == null)) {
       try {
         Token _nextToken = this.tokenSource.nextToken();
         this.token = ((CommonToken) _nextToken);
@@ -117,8 +115,8 @@ public class AntlrDelegatingIdeaLexer extends LexerBase {
           throw Exceptions.sneakyThrow(_t);
         }
       }
-      boolean _equals_1 = Objects.equal(this.token, Token.EOF_TOKEN);
-      if (_equals_1) {
+      boolean _equals = Objects.equal(this.token, Token.EOF_TOKEN);
+      if (_equals) {
         this.token = null;
       }
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/PsiXtextTokenStream.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/parser/PsiXtextTokenStream.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.parser;
 
-import com.google.common.base.Objects;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.psi.tree.IElementType;
@@ -53,8 +52,7 @@ public class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStr
   
   @Override
   public void reportError(final Function0<? extends String> reporter) {
-    boolean _equals = Objects.equal(this.errorMessage, null);
-    if (_equals) {
+    if ((this.errorMessage == null)) {
       String _apply = reporter.apply();
       this.errorMessage = _apply;
     }
@@ -76,8 +74,7 @@ public class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStr
     while ((!this.builder.eof())) {
       this.consume();
     }
-    boolean _notEquals = (!Objects.equal(this.errorMessage, null));
-    if (_notEquals) {
+    if ((this.errorMessage != null)) {
       this.builder.error(this.errorMessage);
       this.errorMessage = null;
     }
@@ -110,8 +107,7 @@ public class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStr
     int _channel = token.getChannel();
     final boolean hidden = (_channel == BaseRecognizer.HIDDEN);
     IElementType _xifexpression = null;
-    boolean _equals = Objects.equal(tokenType, null);
-    if (_equals) {
+    if ((tokenType == null)) {
       _xifexpression = this.builder.getTokenType();
     } else {
       _xifexpression = tokenType;
@@ -123,8 +119,7 @@ public class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStr
     CreateElementType _createElementType = new CreateElementType(currentTokenType, _function);
     this.builder.remapCurrentToken(_createElementType);
     final String errorMessage = this.getErrorMessage(token);
-    boolean _notEquals = (!Objects.equal(errorMessage, null));
-    if (_notEquals) {
+    if ((errorMessage != null)) {
       final PsiBuilder.Marker errorMarker = this.builder.mark();
       this.builder.advanceLexer();
       errorMarker.error(errorMessage);
@@ -134,7 +129,7 @@ public class PsiXtextTokenStream extends XtextTokenStream implements PsiTokenStr
   }
   
   protected String getErrorMessage(final Token token) {
-    if (((token.getChannel() != BaseRecognizer.HIDDEN) && (!Objects.equal(this.errorMessage, null)))) {
+    if (((token.getChannel() != BaseRecognizer.HIDDEN) && (this.errorMessage != null))) {
       final String result = this.errorMessage;
       this.errorMessage = null;
       return result;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/pom/AbstractXtextPomDeclarationSearcher.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/pom/AbstractXtextPomDeclarationSearcher.java
@@ -41,8 +41,7 @@ public abstract class AbstractXtextPomDeclarationSearcher extends PomDeclaration
         _textRange=_nameIdentifier.getTextRange();
       }
       final TextRange nameIdentifierRange = _textRange;
-      boolean _notEquals_1 = (!Objects.equal(nameIdentifierRange, null));
-      if (_notEquals_1) {
+      if ((nameIdentifierRange != null)) {
         TextRange _textRange_1 = ((PsiNamedEObject)element).getTextRange();
         int _startOffset = _textRange_1.getStartOffset();
         final int offsetInDocument = (_startOffset + offsetInElement);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/presentation/DefaultItemPresentationProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/presentation/DefaultItemPresentationProvider.java
@@ -78,8 +78,7 @@ public class DefaultItemPresentationProvider implements ItemPresentationProvider
       EClass _eClass = element.eClass();
       final EAttribute labelFeature = this.getLabelFeature(_eClass);
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(labelFeature, null));
-      if (_notEquals) {
+      if ((labelFeature != null)) {
         Object _eGet = element.eGet(labelFeature);
         String _string = null;
         if (_eGet!=null) {
@@ -102,8 +101,7 @@ public class DefaultItemPresentationProvider implements ItemPresentationProvider
         if (_equalsIgnoreCase) {
           return eAttribute;
         } else {
-          boolean _equals = Objects.equal(result, null);
-          if (_equals) {
+          if ((result == null)) {
             result = eAttribute;
           } else {
             if ((Objects.equal(eAttribute.getEAttributeType().getInstanceClass(), String.class) && 

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/refactoring/NullNamesValidator.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/refactoring/NullNamesValidator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.refactoring;
 
-import com.google.common.base.Objects;
 import com.intellij.lang.refactoring.NamesValidator;
 import com.intellij.openapi.project.Project;
 
@@ -15,7 +14,7 @@ import com.intellij.openapi.project.Project;
 public class NullNamesValidator implements NamesValidator {
   @Override
   public boolean isIdentifier(final String name, final Project project) {
-    return (!Objects.equal(name, null));
+    return (name != null);
   }
   
   @Override

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ErrorContext.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ErrorContext.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.idea.resource.PsiToEcoreTransformationContext;
@@ -21,8 +20,8 @@ public class ErrorContext {
   public EObject getCurrentContext() {
     EObject _xifexpression = null;
     ICompositeNode _currentNode = this.getCurrentNode();
-    boolean _notEquals = (!Objects.equal(_currentNode, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_currentNode != null);
+    if (_tripleNotEquals) {
       ICompositeNode _currentNode_1 = this.getCurrentNode();
       _xifexpression = _currentNode_1.getSemanticElement();
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaClasspathURIResolver.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaClasspathURIResolver.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
@@ -49,7 +48,7 @@ public class IdeaClasspathURIResolver implements IClasspathUriResolver {
       for (final PsiFile file : files) {
         {
           final VirtualFile vf = XtextPsiUtils.findVirtualFile(file);
-          if (((!Objects.equal(vf, null)) && vf.exists())) {
+          if (((vf != null) && vf.exists())) {
             final URI uri = VirtualFileURIUtil.getURI(vf);
             String _string = uri.toString();
             String _path = classpathUri.path();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaEncodingProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaEncodingProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -24,8 +23,7 @@ public class IdeaEncodingProvider implements IEncodingProvider {
   public String getEncoding(final URI uri) {
     Application _application = ApplicationManager.getApplication();
     final VirtualFileManager fileManager = _application.<VirtualFileManager>getComponent(VirtualFileManager.class);
-    boolean _equals = Objects.equal(fileManager, null);
-    if (_equals) {
+    if ((fileManager == null)) {
       IEncodingProvider.Runtime _runtime = new IEncodingProvider.Runtime();
       return _runtime.getEncoding(uri);
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaResourceDescriptionsProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaResourceDescriptionsProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.IResourceDescriptionsProvider;
@@ -21,8 +20,7 @@ public class IdeaResourceDescriptionsProvider implements IResourceDescriptionsPr
   @Override
   public IResourceDescriptions getResourceDescriptions(final ResourceSet resourceSet) {
     final ChunkedResourceDescriptions index = ChunkedResourceDescriptions.findInEmfObject(resourceSet);
-    boolean _notEquals = (!Objects.equal(index, null));
-    if (_notEquals) {
+    if ((index != null)) {
       return index;
     }
     throw new IllegalStateException("No index installed.");

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaResourceSetProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/IdeaResourceSetProvider.java
@@ -153,7 +153,7 @@ public class IdeaResourceSetProvider {
           for (final URI uri_1 : localDeleted) {
             {
               final VirtualFile file = VirtualFileURIUtil.getVirtualFile(uri_1);
-              if (((!Objects.equal(file, null)) && file.exists())) {
+              if (((file != null) && file.exists())) {
                 Object _requestor = this.getRequestor();
                 file.delete(_requestor);
               }
@@ -183,14 +183,12 @@ public class IdeaResourceSetProvider {
         return new ByteArrayInputStream(_get.content);
       }
       final VirtualFile virtualFile = VirtualFileURIUtil.getVirtualFile(uri);
-      boolean _equals = Objects.equal(virtualFile, null);
-      if (_equals) {
+      if ((virtualFile == null)) {
         throw new FileNotFoundException(("Couldn\'t find virtual file for " + uri));
       }
       FileDocumentManager _instance = FileDocumentManager.getInstance();
       final Document cachedDocument = _instance.getCachedDocument(virtualFile);
-      boolean _notEquals = (!Objects.equal(cachedDocument, null));
-      if (_notEquals) {
+      if ((cachedDocument != null)) {
         String _text = cachedDocument.getText();
         Charset _charset = virtualFile.getCharset();
         return new LazyStringInputStream(_text, _charset);
@@ -245,8 +243,8 @@ public class IdeaResourceSetProvider {
         return true;
       }
       IdeaResourceSetProvider.VirtualFileBasedUriHandler.ContentDescriptor _folderDescriptor = this.getFolderDescriptor(uri);
-      boolean _notEquals = (!Objects.equal(_folderDescriptor, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_folderDescriptor != null);
+      if (_tripleNotEquals) {
         return true;
       }
       VirtualFile _virtualFile = VirtualFileURIUtil.getVirtualFile(uri);
@@ -265,12 +263,11 @@ public class IdeaResourceSetProvider {
       }
       Object _get = options.get(URIConverter.OPTION_REQUESTED_ATTRIBUTES);
       final Set<String> requestedAttributes = ((Set<String>) _get);
-      if ((Objects.equal(requestedAttributes, null) || requestedAttributes.isEmpty())) {
+      if (((requestedAttributes == null) || requestedAttributes.isEmpty())) {
         return CollectionLiterals.<String, Object>emptyMap();
       }
       final IdeaResourceSetProvider.VirtualFileBasedUriHandler.ContentDescriptor fileDescriptor = this.writtenContents.get(uri);
-      boolean _notEquals = (!Objects.equal(fileDescriptor, null));
-      if (_notEquals) {
+      if ((fileDescriptor != null)) {
         final HashMap<String, Object> attributes = CollectionLiterals.<String, Object>newHashMap();
         boolean _contains_1 = requestedAttributes.contains(URIConverter.ATTRIBUTE_DIRECTORY);
         if (_contains_1) {
@@ -283,8 +280,7 @@ public class IdeaResourceSetProvider {
         return attributes;
       }
       final IdeaResourceSetProvider.VirtualFileBasedUriHandler.ContentDescriptor folderDescriptor = this.getFolderDescriptor(uri);
-      boolean _notEquals_1 = (!Objects.equal(folderDescriptor, null));
-      if (_notEquals_1) {
+      if ((folderDescriptor != null)) {
         final HashMap<String, Object> attributes_1 = CollectionLiterals.<String, Object>newHashMap();
         boolean _contains_3 = requestedAttributes.contains(URIConverter.ATTRIBUTE_DIRECTORY);
         if (_contains_3) {
@@ -297,8 +293,7 @@ public class IdeaResourceSetProvider {
         return attributes_1;
       }
       final VirtualFile file = VirtualFileURIUtil.getVirtualFile(uri);
-      boolean _notEquals_2 = (!Objects.equal(file, null));
-      if (_notEquals_2) {
+      if ((file != null)) {
         final HashMap<String, Object> attributes_2 = CollectionLiterals.<String, Object>newHashMap();
         boolean _contains_5 = requestedAttributes.contains(URIConverter.ATTRIBUTE_DIRECTORY);
         if (_contains_5) {
@@ -345,8 +340,7 @@ public class IdeaResourceSetProvider {
       {
         final VirtualFile file = VirtualFileURIUtil.getVirtualFile(uri);
         Set<URI> _xifexpression = null;
-        boolean _notEquals = (!Objects.equal(file, null));
-        if (_notEquals) {
+        if ((file != null)) {
           VirtualFile[] _children = file.getChildren();
           final Function1<VirtualFile, URI> _function = (VirtualFile it) -> {
             return VirtualFileURIUtil.getURI(it);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/PsiToEcoreTransformationContext.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/PsiToEcoreTransformationContext.java
@@ -177,14 +177,13 @@ public class PsiToEcoreTransformationContext {
   public PsiToEcoreTransformationContext merge(final PsiToEcoreTransformationContext childTransformationContext, final boolean forced) {
     PsiToEcoreTransformationContext _xblockexpression = null;
     {
-      if ((Objects.equal(this.current, null) || forced)) {
+      if (((this.current == null) || forced)) {
         this.current = childTransformationContext.current;
       }
-      if (((!Objects.equal(this.datatypeRuleToken, null)) && (!Objects.equal(childTransformationContext.datatypeRuleToken, null)))) {
+      if (((this.datatypeRuleToken != null) && (childTransformationContext.datatypeRuleToken != null))) {
         this.datatypeRuleToken.merge(childTransformationContext.datatypeRuleToken);
       }
-      boolean _equals = Objects.equal(this.enumerator, null);
-      if (_equals) {
+      if ((this.enumerator == null)) {
         this.enumerator = childTransformationContext.enumerator;
       }
       _xblockexpression = this;
@@ -240,8 +239,7 @@ public class PsiToEcoreTransformationContext {
   private boolean ensureModelElementCreated(final EObject grammarElement, final ICompositeNode currentNode) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(grammarElement, null);
-      if (_equals) {
+      if ((grammarElement == null)) {
         return false;
       }
       if ((grammarElement instanceof Action)) {
@@ -257,8 +255,7 @@ public class PsiToEcoreTransformationContext {
       if (_not) {
         boolean _isEObjectFragmentRuleCall = GrammarUtil.isEObjectFragmentRuleCall(grammarElement);
         if (_isEObjectFragmentRuleCall) {
-          boolean _notEquals = (!Objects.equal(this.current, null));
-          if (_notEquals) {
+          if ((this.current != null)) {
             return true;
           }
           ParserRule _containingParserRule = GrammarUtil.containingParserRule(grammarElement);
@@ -288,8 +285,7 @@ public class PsiToEcoreTransformationContext {
         }
         return false;
       }
-      boolean _notEquals_1 = (!Objects.equal(this.current, null));
-      if (_notEquals_1) {
+      if ((this.current != null)) {
         return true;
       }
       ParserRule _containingParserRule_1 = GrammarUtil.containingParserRule(grammarElement);
@@ -357,8 +353,7 @@ public class PsiToEcoreTransformationContext {
   }
   
   protected void mergeDatatypeRuleToken(final LeafElement it) {
-    boolean _notEquals = (!Objects.equal(this.datatypeRuleToken, null));
-    if (_notEquals) {
+    if ((this.datatypeRuleToken != null)) {
       AntlrDatatypeRuleToken _antlrDatatypeRuleToken = new AntlrDatatypeRuleToken();
       final Procedure1<AntlrDatatypeRuleToken> _function = (AntlrDatatypeRuleToken token) -> {
         String _text = it.getText();
@@ -374,8 +369,8 @@ public class PsiToEcoreTransformationContext {
   public ICompositeNode assign(final EObject value, final Action action) {
     ICompositeNode _xifexpression = null;
     String _feature = action.getFeature();
-    boolean _notEquals = (!Objects.equal(_feature, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_feature != null);
+    if (_tripleNotEquals) {
       String _operator = action.getOperator();
       String _feature_1 = action.getFeature();
       _xifexpression = this.assign(this.current, _operator, _feature_1, value, null, this.currentNode);
@@ -419,8 +414,7 @@ public class PsiToEcoreTransformationContext {
       }
       final ASTNode astNode = _last;
       boolean _xifexpression = false;
-      boolean _notEquals = (!Objects.equal(astNode, null));
-      if (_notEquals) {
+      if ((astNode != null)) {
         final PsiElementProvider _function = () -> {
           return astNode.getPsi();
         };
@@ -538,14 +532,14 @@ public class PsiToEcoreTransformationContext {
   protected ICompositeNode appendError(final INode node, final SyntaxErrorMessage error) {
     ICompositeNode _xifexpression = null;
     SyntaxErrorMessage _syntaxErrorMessage = node.getSyntaxErrorMessage();
-    boolean _equals = Objects.equal(_syntaxErrorMessage, null);
-    if (_equals) {
+    boolean _tripleEquals = (_syntaxErrorMessage == null);
+    if (_tripleEquals) {
       ICompositeNode _xblockexpression = null;
       {
         final INode newNode = this.nodeModelBuilder.setSyntaxError(node, error);
         ICompositeNode _xifexpression_1 = null;
-        boolean _equals_1 = Objects.equal(node, this.currentNode);
-        if (_equals_1) {
+        boolean _equals = Objects.equal(node, this.currentNode);
+        if (_equals) {
           _xifexpression_1 = this.currentNode = ((ICompositeNode) newNode);
         }
         _xblockexpression = _xifexpression_1;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/PsiToEcoreTransformator.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/PsiToEcoreTransformator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.FileASTNode;
@@ -382,8 +381,7 @@ public class PsiToEcoreTransformator implements IParser {
             _xifexpression = childTransformationContext.getEnumerator();
           }
           final Object child = _xifexpression;
-          boolean _notEquals = (!Objects.equal(child, null));
-          if (_notEquals) {
+          if ((child != null)) {
             String _qualifiedName = this.ruleNames.getQualifiedName(rule);
             transformationContext.assign(child, ruleCall, _qualifiedName);
           }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ValueConverterErrorContext.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ValueConverterErrorContext.java
@@ -29,23 +29,19 @@ public class ValueConverterErrorContext extends ErrorContext implements ISyntaxE
       Throwable _cause = this.valueConverterException.getCause();
       final Exception cause = ((Exception) _cause);
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(cause, null));
-      if (_notEquals) {
+      if ((cause != null)) {
         _xifexpression = cause.getMessage();
       } else {
         _xifexpression = this.valueConverterException.getMessage();
       }
       String result = _xifexpression;
-      boolean _equals = Objects.equal(result, null);
-      if (_equals) {
+      if ((result == null)) {
         String _message = this.valueConverterException.getMessage();
         result = _message;
       }
-      boolean _equals_1 = Objects.equal(result, null);
-      if (_equals_1) {
+      if ((result == null)) {
         String _xifexpression_1 = null;
-        boolean _notEquals_1 = (!Objects.equal(cause, null));
-        if (_notEquals_1) {
+        if ((cause != null)) {
           Class<? extends Exception> _class = cause.getClass();
           _xifexpression_1 = _class.getSimpleName();
         } else {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/VirtualFileURIUtil.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/VirtualFileURIUtil.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.resource;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -57,8 +56,7 @@ public class VirtualFileURIUtil {
   private static VirtualFile getOrCreateFile(final URI uri, final boolean isDirectory) {
     try {
       final VirtualFile file = VirtualFileURIUtil.getVirtualFile(uri);
-      boolean _notEquals = (!Objects.equal(file, null));
-      if (_notEquals) {
+      if ((file != null)) {
         return file;
       }
       int _segmentCount = uri.segmentCount();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/AbstractStructureViewTreeElement.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/AbstractStructureViewTreeElement.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.util.treeView.smartTree.TreeElement;
@@ -54,14 +53,12 @@ public abstract class AbstractStructureViewTreeElement implements ModifiableStru
       if (this.leaf) {
         return ((TreeElement[])Conversions.unwrapArray(CollectionLiterals.<TreeElement>emptyList(), TreeElement.class));
       }
-      boolean _equals = Objects.equal(this.children, null);
-      if (_equals) {
+      if ((this.children == null)) {
         ArrayList<StructureViewTreeElement> _newArrayList = CollectionLiterals.<StructureViewTreeElement>newArrayList();
         this.children = _newArrayList;
         this.structureViewTreeElementProvider.buildChildren(this);
       }
-      boolean _equals_1 = Objects.equal(this.children, null);
-      if (_equals_1) {
+      if ((this.children == null)) {
         return ((TreeElement[])Conversions.unwrapArray(CollectionLiterals.<TreeElement>emptyList(), TreeElement.class));
       }
       _xblockexpression = this.children;
@@ -72,12 +69,10 @@ public abstract class AbstractStructureViewTreeElement implements ModifiableStru
   @Override
   public boolean addChild(final StructureViewTreeElement child) {
     boolean _xifexpression = false;
-    boolean _notEquals = (!Objects.equal(child, null));
-    if (_notEquals) {
+    if ((child != null)) {
       boolean _xblockexpression = false;
       {
-        boolean _equals = Objects.equal(this.children, null);
-        if (_equals) {
+        if ((this.children == null)) {
           ArrayList<StructureViewTreeElement> _newArrayList = CollectionLiterals.<StructureViewTreeElement>newArrayList();
           this.children = _newArrayList;
         }
@@ -102,8 +97,7 @@ public abstract class AbstractStructureViewTreeElement implements ModifiableStru
       if (_not) {
         boolean _xblockexpression_1 = false;
         {
-          boolean _equals = Objects.equal(this.children, null);
-          if (_equals) {
+          if ((this.children == null)) {
             ArrayList<StructureViewTreeElement> _newArrayList = CollectionLiterals.<StructureViewTreeElement>newArrayList();
             this.children = _newArrayList;
           }
@@ -162,7 +156,7 @@ public abstract class AbstractStructureViewTreeElement implements ModifiableStru
       {
         final PsiElement element = this.getInternalNavigationElement();
         PsiElement _xifexpression = null;
-        if (((!Objects.equal(element, null)) && element.isValid())) {
+        if (((element != null) && element.isValid())) {
           _xifexpression = element;
         }
         _xblockexpression = _xifexpression;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/AlphaSorter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/AlphaSorter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.IdeBundle;
 import com.intellij.ide.util.treeView.smartTree.ActionPresentation;
@@ -27,7 +26,7 @@ public class AlphaSorter implements Sorter {
   
   @Override
   public boolean isVisible() {
-    return (!Objects.equal(this.comparator, null));
+    return (this.comparator != null);
   }
   
   @Override

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/DefaultStructureViewTreeElementProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/DefaultStructureViewTreeElementProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -62,8 +61,7 @@ public class DefaultStructureViewTreeElementProvider implements IStructureViewTr
     XtextResource _resource = _element.getResource();
     EList<EObject> _contents = _resource.getContents();
     final EObject modelElement = IterableExtensions.<EObject>head(_contents);
-    boolean _equals = Objects.equal(modelElement, null);
-    if (_equals) {
+    if ((modelElement == null)) {
       return;
     }
     ItemPresentation _elvis = null;
@@ -77,8 +75,8 @@ public class DefaultStructureViewTreeElementProvider implements IStructureViewTr
     final ItemPresentation itemPresentation = _elvis;
     if ((itemPresentation instanceof PresentationData)) {
       String _presentableText = ((PresentationData)itemPresentation).getPresentableText();
-      boolean _equals_1 = Objects.equal(_presentableText, null);
-      if (_equals_1) {
+      boolean _tripleEquals = (_presentableText == null);
+      if (_tripleEquals) {
         Resource _eResource = modelElement.eResource();
         URI _uRI = _eResource.getURI();
         URI _trimFileExtension = _uRI.trimFileExtension();
@@ -139,8 +137,8 @@ public class DefaultStructureViewTreeElementProvider implements IStructureViewTr
       if (itemPresentation!=null) {
         _presentableText=itemPresentation.getPresentableText();
       }
-      boolean _equals = Objects.equal(_presentableText, null);
-      if (!_equals) {
+      boolean _tripleEquals = (_presentableText == null);
+      if (!_tripleEquals) {
         _and = false;
       } else {
         _and = leaf;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/XtextFileTreeElement.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/XtextFileTreeElement.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
@@ -42,8 +41,7 @@ public class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> impl
     {
       this.children = null;
       this.structureViewTreeElementProvider.buildChildren(this);
-      boolean _equals = Objects.equal(this.children, null);
-      if (_equals) {
+      if ((this.children == null)) {
         return CollectionLiterals.<StructureViewTreeElement>emptyList();
       }
       _xblockexpression = this.children;
@@ -60,12 +58,10 @@ public class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> impl
   @Override
   public boolean addChild(final StructureViewTreeElement child) {
     boolean _xifexpression = false;
-    boolean _notEquals = (!Objects.equal(child, null));
-    if (_notEquals) {
+    if ((child != null)) {
       boolean _xblockexpression = false;
       {
-        boolean _equals = Objects.equal(this.children, null);
-        if (_equals) {
+        if ((this.children == null)) {
           ArrayList<StructureViewTreeElement> _newArrayList = CollectionLiterals.<StructureViewTreeElement>newArrayList();
           this.children = _newArrayList;
         }
@@ -89,8 +85,7 @@ public class XtextFileTreeElement extends PsiTreeElementBase<BaseXtextFile> impl
       if (_not) {
         boolean _xblockexpression_1 = false;
         {
-          boolean _equals = Objects.equal(this.children, null);
-          if (_equals) {
+          if ((this.children == null)) {
             ArrayList<StructureViewTreeElement> _newArrayList = CollectionLiterals.<StructureViewTreeElement>newArrayList();
             this.children = _newArrayList;
           }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/XtextFileTreeModel.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/structureview/XtextFileTreeModel.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.intellij.ide.structureView.StructureViewModel;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.structureView.TextEditorBasedStructureViewModel;
@@ -65,8 +64,7 @@ public class XtextFileTreeModel extends TextEditorBasedStructureViewModel implem
     ArrayList<Sorter> _newArrayList = CollectionLiterals.<Sorter>newArrayList();
     this.sorters = _newArrayList;
     final Comparator<TreeElement> comparator = this.getComparator();
-    boolean _notEquals = (!Objects.equal(comparator, null));
-    if (_notEquals) {
+    if ((comparator != null)) {
       AlphaSorter _alphaSorter = new AlphaSorter();
       final Procedure1<AlphaSorter> _function = (AlphaSorter it) -> {
         it.setComparator(comparator);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceBasedGeneratedSourcesFilter.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceBasedGeneratedSourcesFilter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.trace;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.ide.projectView.impl.ProjectViewPane;
 import com.intellij.openapi.application.Application;
@@ -50,7 +49,7 @@ public class TraceBasedGeneratedSourcesFilter extends GeneratedSourcesFilter {
       Project _project = element.getProject();
       IdeFocusManager _instance = IdeFocusManager.getInstance(_project);
       final Component focusOwner = _instance.getFocusOwner();
-      if (((!Objects.equal(focusOwner, null)) && focusOwner.getClass().getName().startsWith(ProjectViewPane.class.getName()))) {
+      if (((focusOwner != null) && focusOwner.getClass().getName().startsWith(ProjectViewPane.class.getName()))) {
         return CollectionLiterals.<PsiElement>emptyList();
       }
     }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.trace;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.intellij.openapi.application.Application;
@@ -249,8 +248,7 @@ public class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<Vir
         for (final VirtualFile contentRoot : _contentRoots) {
           {
             final VirtualFile result = contentRoot.findFileByRelativePath(outputFolder);
-            boolean _notEquals = (!Objects.equal(result, null));
-            if (_notEquals) {
+            if ((result != null)) {
               return result;
             }
           }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/VirtualFileInProject.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/VirtualFileInProject.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.trace;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
@@ -26,8 +25,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 public class VirtualFileInProject {
   public static VirtualFileInProject forPsiElement(final PsiElement element) {
     final VirtualFile virtualFile = XtextPsiUtils.findVirtualFile(element);
-    boolean _equals = Objects.equal(virtualFile, null);
-    if (_equals) {
+    if ((virtualFile == null)) {
       return null;
     }
     Project _project = element.getProject();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/GlobalPsiModelAssociations.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/GlobalPsiModelAssociations.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.psi;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.intellij.psi.PsiElement;
@@ -33,8 +32,7 @@ public class GlobalPsiModelAssociations implements IPsiModelAssociations {
   
   @Override
   public EObject getEObject(final PsiElement element) {
-    boolean _equals = Objects.equal(element, null);
-    if (_equals) {
+    if ((element == null)) {
       return null;
     }
     final PsiFile containingFile = element.getContainingFile();
@@ -53,8 +51,7 @@ public class GlobalPsiModelAssociations implements IPsiModelAssociations {
   public PsiElement getPsiElement(final EObject object) {
     PsiElement _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(object, null);
-      if (_equals) {
+      if ((object == null)) {
         return null;
       }
       URI _uRI = EcoreUtil.getURI(object);
@@ -74,7 +71,7 @@ public class GlobalPsiModelAssociations implements IPsiModelAssociations {
   public PsiElement getPsiElement(final IEObjectDescription objectDescription, final Resource context) {
     PsiElement _xblockexpression = null;
     {
-      if ((Objects.equal(objectDescription, null) || Objects.equal(context, null))) {
+      if (((objectDescription == null) || (context == null))) {
         return null;
       }
       final URI resourceURI = context.getURI();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/XtextPsiExtensions.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/XtextPsiExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.psi;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
@@ -38,7 +37,7 @@ public class XtextPsiExtensions {
   public PsiElement findEObjectAssociatedPsiElement(final PsiElement element) {
     final Condition<PsiElement> _function = (PsiElement it) -> {
       EObject _eObject = this.associations.getEObject(it);
-      return (!Objects.equal(_eObject, null));
+      return (_eObject != null);
     };
     return PsiTreeUtil.findFirstParent(element, false, _function);
   }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/XtextPsiUtils.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/XtextPsiUtils.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.psi;
 
-import com.google.common.base.Objects;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;
@@ -34,8 +33,7 @@ public class XtextPsiUtils {
       return _viewProvider.getVirtualFile();
     } else {
       VirtualFile _xifexpression_1 = null;
-      boolean _equals = Objects.equal(element, null);
-      if (_equals) {
+      if ((element == null)) {
         return null;
       } else {
         PsiFile _containingFile = element.getContainingFile();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiEObjectFactoryImpl.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiEObjectFactoryImpl.java
@@ -145,8 +145,8 @@ public class PsiEObjectFactoryImpl implements PsiEObjectFactory {
       return Boolean.valueOf(_xblockexpression);
     };
     treeElement.acceptTree(((RecursiveTreeElementVisitor) new RecursiveTreeElementVisitor() {
-        public boolean visitNode(TreeElement arg0) {
-          return _function.apply(arg0);
+        public boolean visitNode(TreeElement element) {
+          return _function.apply(element);
         }
     }));
   }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiEObjectImpl.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiEObjectImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.psi.impl;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.extapi.psi.StubBasedPsiElementBase;
 import com.intellij.icons.AllIcons;
@@ -166,16 +165,14 @@ public class PsiEObjectImpl<PsiT extends PsiElement, T extends StubElement<PsiT>
     if ((reference instanceof XtextPsiReference)) {
       final int textOffset = super.getTextOffset();
       final TextRange rangeToHighlightInElement = ((XtextPsiReference)reference).getRangeToHighlightInElement();
-      boolean _notEquals = (!Objects.equal(rangeToHighlightInElement, null));
-      if (_notEquals) {
+      if ((rangeToHighlightInElement != null)) {
         int _startOffset = rangeToHighlightInElement.getStartOffset();
         return (textOffset + _startOffset);
       }
       return textOffset;
     }
     final ITextRegion textRegion = this.getSignificantTextRegion();
-    boolean _notEquals_1 = (!Objects.equal(textRegion, null));
-    if (_notEquals_1) {
+    if ((textRegion != null)) {
       return textRegion.getOffset();
     }
     return super.getTextOffset();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiNamedEObjectImpl.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/PsiNamedEObjectImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.psi.impl;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
@@ -56,8 +55,7 @@ public class PsiNamedEObjectImpl<PsiE extends PsiNamedEObject, T extends PsiName
     PsiEObjectIdentifierImpl _xblockexpression = null;
     {
       final ASTNode nameNode = this.findNameNode();
-      boolean _equals = Objects.equal(nameNode, null);
-      if (_equals) {
+      if ((nameNode == null)) {
         return null;
       }
       PsiElement _psi = nameNode.getPsi();
@@ -69,8 +67,7 @@ public class PsiNamedEObjectImpl<PsiE extends PsiNamedEObject, T extends PsiName
   @Override
   public String getName() {
     final T stub = this.getStub();
-    boolean _notEquals = (!Objects.equal(stub, null));
-    if (_notEquals) {
+    if ((stub != null)) {
       return stub.getName();
     }
     final ITextRegion significantTextRegion = this.getSignificantTextRegion();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/XtextPsiReferenceImpl.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/psi/impl/XtextPsiReferenceImpl.java
@@ -214,8 +214,7 @@ public class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> imp
     {
       ProgressIndicatorProvider.checkCanceled();
       ICrossReferenceDescription crossReferenceDescription = this.getCrossReferenceDescription();
-      boolean _equals = Objects.equal(crossReferenceDescription, null);
-      if (_equals) {
+      if ((crossReferenceDescription == null)) {
         return ((Object[])Conversions.unwrapArray(CollectionLiterals.<Object>emptyList(), Object.class));
       }
       ArrayList<LookupElementBuilder> variants = CollectionLiterals.<LookupElementBuilder>newArrayList();
@@ -229,8 +228,7 @@ public class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> imp
             BaseXtextFile _xtextFile = this.myElement.getXtextFile();
             XtextResource _resource = _xtextFile.getResource();
             PsiElement element = this.psiModelAssociations.getPsiElement(objectDescription, _resource);
-            boolean _notEquals = (!Objects.equal(element, null));
-            if (_notEquals) {
+            if ((element != null)) {
               LookupElementBuilder _create = LookupElementBuilder.create(name);
               PsiElement _navigationElement = element.getNavigationElement();
               PsiFile _containingFile = _navigationElement.getContainingFile();
@@ -252,8 +250,7 @@ public class XtextPsiReferenceImpl extends PsiReferenceBase<XtextPsiElement> imp
     {
       ProgressIndicatorProvider.checkCanceled();
       ICrossReferenceDescription crossReferenceDescription = this.getCrossReferenceDescription();
-      boolean _equals = Objects.equal(crossReferenceDescription, null);
-      if (_equals) {
+      if ((crossReferenceDescription == null)) {
         return null;
       }
       EObject object = crossReferenceDescription.resolve();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/annotations/idea/completion/XbaseWithAnnotationsCompletionContributor.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/annotations/idea/completion/XbaseWithAnnotationsCompletionContributor.java
@@ -62,7 +62,7 @@ public class XbaseWithAnnotationsCompletionContributor extends XbaseCompletionCo
         PsiElement _position = $0.getPosition();
         final Condition<PsiElement> _function = (PsiElement it) -> {
           EObject _eObject = XbaseWithAnnotationsCompletionContributor.this._iPsiModelAssociations.getEObject(it);
-          return (!Objects.equal(_eObject, null));
+          return (_eObject != null);
         };
         final PsiElement psiElement = PsiTreeUtil.findFirstParent(_position, false, _function);
         EObject _eObject = XbaseWithAnnotationsCompletionContributor.this._iPsiModelAssociations.getEObject(psiElement);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/facet/XbaseFacetForm.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/facet/XbaseFacetForm.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.idea.facet;
 
-import com.google.common.base.Objects;
 import com.intellij.facet.ui.FacetValidatorsManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -188,8 +187,8 @@ public class XbaseFacetForm extends GeneratorFacetForm {
         return Boolean.valueOf((_name == _targetJavaVersion));
       };
       LanguageLevel _findFirst = IterableExtensions.<LanguageLevel>findFirst(((Iterable<LanguageLevel>)Conversions.doWrapArray(_values)), _function);
-      boolean _notEquals = (!Objects.equal(_findFirst, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_findFirst != null);
+      if (_tripleNotEquals) {
         String _targetJavaVersion = ((XbaseGeneratorConfigurationState)data).getTargetJavaVersion();
         LanguageLevel _valueOf = LanguageLevel.valueOf(_targetJavaVersion);
         this.targetJavaVersion.setSelectedItem(_valueOf);
@@ -311,8 +310,8 @@ public class XbaseFacetForm extends GeneratorFacetForm {
   
   public LanguageLevelCombo createLanguageLevelCombo() {
     abstract class __XbaseFacetForm_1 extends LanguageLevelCombo {
-      __XbaseFacetForm_1(final String arg0) {
-        super(arg0);
+      __XbaseFacetForm_1(final String defaultItem) {
+        super(defaultItem);
       }
       
       LanguageLevelModuleExtension llExt;
@@ -326,8 +325,7 @@ public class XbaseFacetForm extends GeneratorFacetForm {
       @Override
       protected LanguageLevel getDefaultLevel() {
         LanguageLevel langLevel = this.llExt.getLanguageLevel();
-        boolean _equals = Objects.equal(langLevel, null);
-        if (_equals) {
+        if ((langLevel == null)) {
           Module _module = XbaseFacetForm.this.getModule();
           Project _project = _module.getProject();
           LanguageLevelProjectExtensionImpl _instanceImpl = LanguageLevelProjectExtensionImpl.getInstanceImpl(_project);

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/facet/XbaseGeneratorConfigProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/facet/XbaseGeneratorConfigProvider.java
@@ -86,7 +86,7 @@ public class XbaseGeneratorConfigProvider implements IGeneratorConfigProvider {
     {
       final String version = state.getTargetJavaVersion();
       LanguageLevel _xifexpression = null;
-      if ((Objects.equal(version, null) || version.equals("Module default"))) {
+      if (((version == null) || version.equals("Module default"))) {
         LanguageLevel _xblockexpression_1 = null;
         {
           final Computable<LanguageLevel> _function = () -> {

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/findusages/JvmElementAwareReferenceSearcher.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/findusages/JvmElementAwareReferenceSearcher.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.idea.findusages;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.intellij.lang.Language;
@@ -85,8 +84,7 @@ public class JvmElementAwareReferenceSearcher implements IReferenceSearcher {
   }
   
   protected void accept(final Set<String> words, final String word) {
-    boolean _notEquals = (!Objects.equal(word, null));
-    if (_notEquals) {
+    if ((word != null)) {
       words.add(word);
     }
   }
@@ -108,13 +106,11 @@ public class JvmElementAwareReferenceSearcher implements IReferenceSearcher {
     String _simpleName_1 = jvmElement.getSimpleName();
     QualifiedName _create = QualifiedName.create(_simpleName_1);
     final QualifiedName simpleOperator = this._operatorMapping.getOperator(_create);
-    boolean _notEquals = (!Objects.equal(simpleOperator, null));
-    if (_notEquals) {
+    if ((simpleOperator != null)) {
       String _string = simpleOperator.toString();
       acceptor.apply(_string);
       final QualifiedName compoundOperator = this._operatorMapping.getCompoundOperator(simpleOperator);
-      boolean _notEquals_1 = (!Objects.equal(compoundOperator, null));
-      if (_notEquals_1) {
+      if ((compoundOperator != null)) {
         String _string_1 = compoundOperator.toString();
         acceptor.apply(_string_1);
       }

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/findusages/XbaseWordsScanner.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/findusages/XbaseWordsScanner.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.idea.findusages;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -52,7 +51,7 @@ public class XbaseWordsScanner implements WordsScanner {
   @Override
   public void processWords(final CharSequence fileText, final Processor<WordOccurrence> processor) {
     this.lexer.start(fileText);
-    while ((!Objects.equal(this.lexer.getTokenType(), null))) {
+    while ((this.lexer.getTokenType() != null)) {
       {
         this.scanOperator(processor);
         this.scanWords(processor);
@@ -90,8 +89,8 @@ public class XbaseWordsScanner implements WordsScanner {
   
   protected void scanWords(final Processor<WordOccurrence> processor) {
     IElementType _tokenType = this.lexer.getTokenType();
-    boolean _equals = Objects.equal(_tokenType, null);
-    if (_equals) {
+    boolean _tripleEquals = (_tokenType == null);
+    if (_tripleEquals) {
       return;
     }
     final WordOccurrence.Kind kind = this.getOccurrenceKind();

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/formatting/XbaseBlockFactory.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/formatting/XbaseBlockFactory.java
@@ -117,8 +117,7 @@ public class XbaseBlockFactory extends DefaultBlockFactory {
   protected boolean isContinuation(final EObject grammarElement) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(grammarElement, null);
-      if (_equals) {
+      if ((grammarElement == null)) {
         return false;
       }
       boolean _switchResult = false;
@@ -241,8 +240,7 @@ public class XbaseBlockFactory extends DefaultBlockFactory {
   protected boolean isStructural(final EObject grammarElement) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(grammarElement, null);
-      if (_equals) {
+      if ((grammarElement == null)) {
         return false;
       }
       boolean _switchResult = false;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/formatting/XbaseChildAttributesProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/formatting/XbaseChildAttributesProvider.java
@@ -29,8 +29,7 @@ public class XbaseChildAttributesProvider extends DefaultChildAttributesProvider
   
   @Override
   protected Indent getIndentAfter(final EObject grammarElement) {
-    boolean _equals = Objects.equal(grammarElement, null);
-    if (_equals) {
+    if ((grammarElement == null)) {
       return null;
     }
     boolean _matched = false;

--- a/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/presentation/XbaseItemPresentationProvider.java
+++ b/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/xbase/idea/presentation/XbaseItemPresentationProvider.java
@@ -154,8 +154,7 @@ public class XbaseItemPresentationProvider extends DefaultItemPresentationProvid
     {
       final JvmTypeReference parameterType = parameter.getParameterType();
       String _xifexpression = null;
-      boolean _equals = Objects.equal(parameterType, null);
-      if (_equals) {
+      if ((parameterType == null)) {
         _xifexpression = parameter.getName();
       } else {
         String _simpleName = parameterType.getSimpleName();
@@ -178,8 +177,8 @@ public class XbaseItemPresentationProvider extends DefaultItemPresentationProvid
         _builder.append(".*");
       } else {
         String _memberName = it.getMemberName();
-        boolean _notEquals = (!Objects.equal(_memberName, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_memberName != null);
+        if (_tripleNotEquals) {
           _builder.append(".");
           String _memberName_1 = it.getMemberName();
           _builder.append(_memberName_1, "");
@@ -199,8 +198,7 @@ public class XbaseItemPresentationProvider extends DefaultItemPresentationProvid
       final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(variableDeclaration);
       final LightweightTypeReference type = resolvedTypes.getActualType(((JvmIdentifiableElement) variableDeclaration));
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(type, null));
-      if (_notEquals) {
+      if ((type != null)) {
         String _humanReadableName = type.getHumanReadableName();
         String _plus = (_humanReadableName + " ");
         String _name = variableDeclaration.getName();
@@ -231,8 +229,7 @@ public class XbaseItemPresentationProvider extends DefaultItemPresentationProvid
       final JvmTypeReference returnType = _xifexpression;
       final StandardTypeReferenceOwner owner = new StandardTypeReferenceOwner(this.services, element);
       String _xifexpression_2 = null;
-      boolean _equals = Objects.equal(returnType, null);
-      if (_equals) {
+      if ((returnType == null)) {
         _xifexpression_2 = "void";
       } else {
         LightweightTypeReference _lightweightTypeReference = owner.toLightweightTypeReference(returnType);


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings
