### PR TITLE
widened version range for asm to include version 6 

### DIFF
--- a/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
@@ -23,6 +23,6 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.antlr.runtime,
  org.eclipse.xtext.common.types.tests,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.log4j

--- a/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xbase.lib,
  org.antlr.runtime,
  org.eclipse.xtext.common.types,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.idea.example.entities,


### PR DESCRIPTION
widened version range for asm to include version 6
eclipse/xtext-core#501

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>