### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Require-Bundle: org.eclipse.xtext,
  org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.xtext.idea.common.types.tests

--- a/org.eclipse.xtext.idea.example.entities.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.example.entities.ide/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.idea.example.entities.ide.contentassist.antlr,
  org.eclipse.xtext.idea.example.entities.ide.contentassist.antlr.internal
 
+Automatic-Module-Name: org.eclipse.xtext.idea.example.entities.ide

--- a/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Export-Package: org.eclipse.xtext.idea.example.entities,
  org.eclipse.xtext.idea.example.entities.validation,
  org.eclipse.xtext.idea.example.entities.formatting2,
  org.eclipse.xtext.idea.example.entities.jvmmodel
+Automatic-Module-Name: org.eclipse.xtext.idea.example.entities

--- a/org.eclipse.xtext.idea.sdomain/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.sdomain/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Export-Package: org.eclipse.xtext.idea.sdomain,
  org.eclipse.xtext.idea.sdomain.serializer,
  org.eclipse.xtext.idea.sdomain.services,
  org.eclipse.xtext.idea.sdomain.validation
+Automatic-Module-Name: org.eclipse.xtext.idea.sdomain


### PR DESCRIPTION
Signed-off-by: Florian Stolte <fstolte@itemis.de>