### PR TITLE
[eclipse/xtext#1190] Narrowed the version range for asm to [6.1.1,6.2.0)

### DIFF
--- a/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.common.types.tests/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.antlr.runtime,
  org.eclipse.xtext.common.types.tests,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.log4j
 Automatic-Module-Name: org.eclipse.xtext.idea.common.types.tests

--- a/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.example.entities/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xbase.lib,
  org.antlr.runtime,
  org.eclipse.xtext.common.types,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.idea.example.entities,


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>