### PR TITLE
[eclipse/xtext#1224] Detect local Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
 	}
 	
 	stage('Build') {
-		sh "./gradlew clean build createLocalMavenRepo -PuseJenkinsSnapshots=true -PignoreTestFailures=true --refresh-dependencies --continue"
+		sh "./gradlew clean build createLocalMavenRepo -PuseJenkinsSnapshots=true -PJENKINS_URL=$JENKINS_URL -PignoreTestFailures=true --refresh-dependencies --continue"
 		step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
 		archive 'build/maven-repository/**'
 	}

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -1,13 +1,16 @@
 /*
  * Root project configuration that is reused by subprojects to apply the Xtend compiler.
  */
+if (!hasProperty('JENKINS_URL')) {
+	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
 
 // The repositories to query when constructing the Xtend compiler classpath
 repositories {
 	jcenter()
 	maven {
 		name 'xtend-bootstrap'
-		url 'http://services.typefox.io/open-source/jenkins/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/'
+		url "$JENKINS_URL/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/"
 	}
 }
 

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -6,6 +6,10 @@
  * upstream branch is selected automatically based on the version string.
  */
 
+if (!hasProperty('JENKINS_URL')) {
+	ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+}
+
 if (!hasProperty('upstreamBranch')) {
 	def versionSplit = version.split('\\.')
 	if (versionSplit.length == 4)
@@ -18,17 +22,17 @@ if (!hasProperty('upstreamBranch')) {
 		ext.upstreamBranch = 'release_' + version
 }
 
-def jenkinsPipelineRepo = { jobName -> "http://services.typefox.io/open-source/jenkins/job/$jobName/job/$upstreamBranch/lastStableBuild/artifact/build/maven-repository/" }
+def jenkinsPipelineRepo = { jobName, upstreamBranch -> "$JENKINS_URL/job/$jobName/job/$upstreamBranch/lastStableBuild/artifact/build/maven-repository/" }
 
 repositories {
 	jcenter()
 	// We have dependencies to test projects from xtext-extras, so Jenkins snapshots are the default
 	if (!hasProperty('useJenkinsSnapshots') || findProperty('useJenkinsSnapshots') == 'true') {
 		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
-		maven { url jenkinsPipelineRepo('xtext-lib') }
-		maven { url jenkinsPipelineRepo('xtext-core') }
-		maven { url jenkinsPipelineRepo('xtext-extras') }
-		maven { url jenkinsPipelineRepo('xtext-xtend') }
+		maven { url jenkinsPipelineRepo('xtext-lib','master') }
+		maven { url jenkinsPipelineRepo('xtext-core','master') }
+		maven { url jenkinsPipelineRepo('xtext-extras','master') }
+		maven { url jenkinsPipelineRepo('xtext-xtend','master') }
 	} else {
 		mavenLocal()
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }


### PR DESCRIPTION
Build steps defined in Jenkinsfile pass the built-in environment
variable 'JENKINS_URL' to the Gradle/Maven executions. This is evaluated
in the build scripts for upstream repository URLs. On Xtext JIPP this
will use upstream repos from JIPP. In local builds outside of Jenkins
the property defaults to Typefox CI like before.

Extend function jenkinsPipelineRepo() by upstreamBranch parameter and use this in the call.
Use jenkinsPipelineRepo() also for lsp4j.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>