### PR TITLE
[eclipse/xtext#1404] Bump Xtext-Gradle-Plugin to latest (2.0.4)

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,7 +7,7 @@ version = '2.17.0-SNAPSHOT'
 ext.versions = [
 	'xtext': version,
 	'xtext_bootstrap': '2.17.0.M2',
-	'xtext_gradle_plugin': '2.0.2',
+	'xtext_gradle_plugin': '2.0.4',
 	'idea' : project.hasProperty('ideaEAP') ? 'LATEST-EAP-SNAPSHOT' : '145.972.3',
 	'dependency_management_plugin' : '1.0.6.RELEASE'
 ]


### PR DESCRIPTION
[eclipse/xtext#1404] Bump Xtext-Gradle-Plugin to latest (2.0.4)
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>